### PR TITLE
Add dev-workflow skill: issue-to-PR pipeline with SDD, TDD, hexagonal architecture

### DIFF
--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: dev-workflow
+description: End-to-end development workflow for podlit_py — takes a GitHub issue or a plain instruction and drives it through branch creation, spec-first (SDD) design, TDD (unit tests before code), implementation, integration tests, self-review, PR creation, and CI verification. Use this whenever the user gives you a GitHub issue number/URL to work, or asks to implement a feature, fix a bug, "start work on X", or "open a PR for X" — not just when they explicitly say "follow the dev workflow."
+---
+
+# podlit_py development workflow
+
+A disciplined pipeline from "here's an issue" to "here's a green PR". The point of doing
+spec → tests → code → integration → review in that exact order is that each phase catches a
+different class of mistake early, before it's expensive: the spec catches wrong scope, unit
+tests catch wrong behavior, integration tests catch wrong wiring, self-review catches everything
+that slips past automated checks. Skipping ahead (e.g. writing code before the spec is agreed,
+or opening a PR before checks are green) throws away exactly the safety net that phase provides.
+
+For anything about *how this codebase is built* (Makefile, conda env, module layout,
+what to mock in tests) — see [references/architecture.md](references/architecture.md). This
+file is about the *process*, not the codebase internals.
+
+This project targets a **hexagonal architecture** (ports & adapters) — domain and application
+logic must not depend directly on `TTS`, `torch`, `cv2`, or `tkinter`; those live behind ports
+implemented by adapters. See [references/hexagonal-architecture.md](references/hexagonal-architecture.md)
+for the target package layout and the incremental migration strategy — step 5 (implementation)
+applies it.
+
+## The phases, in order
+
+1. Intake
+2. Create branch
+3. Spec first (SDD) — **stop for user confirmation**
+4. Unit tests first (TDD, red)
+5. Implementation (green)
+6. Integration tests
+7. Self-review
+8. Fix findings
+9. Generate PR — **requires explicit user confirmation**
+10. Verify CI checks
+
+Don't reorder or silently skip a phase. If the user explicitly asks to skip one for a given
+task ("skip the spec, just fix the typo"), that's their call to make per-task — but the default
+is the full pipeline.
+
+## 1. Intake
+
+- Given a GitHub issue number or URL: `gh issue view <num> --json number,title,body,labels,url`.
+  Treat the issue's title/body/labels as the primary source of scope.
+- Given a plain instruction instead: treat the user's message itself as the spec seed — there's
+  nothing to fetch.
+- If scope is ambiguous or missing something a test would need (acceptance criteria, exact
+  expected behavior on edge cases, affected files), ask now. It's much cheaper to ask before a
+  branch or any file exists than to redo a spec later.
+
+## 2. Create branch
+
+- Check `git status` first — if there's uncommitted work, stash or ask before switching.
+- Base off `develop` (this repo's main branch).
+- Name: `feature/<slug>` for new capability, `fix/<slug>` for bug fixes — infer which from
+  issue labels (`bug` → fix) or from the instruction's intent. `<slug>` is short kebab-case
+  from the issue title/instruction, consistent with existing branches like `feature/edit_task`,
+  `fix/add_task_name`.
+
+```bash
+git checkout -b feature/<slug>
+```
+
+## 3. Spec first (SDD)
+
+Write `specs/<same-slug-as-branch>.md` using [references/spec-template.md](references/spec-template.md).
+The spec exists to pin down scope and acceptance criteria *before* a single test or line of code
+exists — it's the contract that both the unit tests (step 4) and the self-review (step 7) get
+checked against later, so vague criteria here just become vague tests later.
+
+Ask the user any clarifying questions the issue/instruction leaves open — edge cases, exact
+expected text/format, error handling behavior, which files are in scope. Resolve these as spec
+content, not as assumptions buried in code.
+
+**Stop here.** Show the user the spec and wait for explicit confirmation that it's correct
+before writing any test. This is the one phase-gate the user asked to always pause at — treat
+"looks fine, keep going" as sufficient, but don't infer approval from silence or move on
+speculatively while waiting.
+
+## 4. Unit tests first (TDD — red)
+
+- Location: `tests/unit/`, pytest naming (`test_*.py`), one test module per source module.
+- Derive test cases directly from the spec's numbered acceptance criteria — every criterion
+  should map to at least one test. If a criterion can't be turned into a test, that's a sign
+  the spec needs to be more concrete, not that the criterion should be skipped.
+- Run them and confirm they fail for the *right* reason (missing implementation — `ImportError`,
+  `NotImplementedError`, wrong return value) rather than a typo in the test itself:
+
+```bash
+pytest tests/unit -x
+```
+
+- If pytest isn't set up yet, add it (`pip install pytest` inside the `tts` conda env, plus
+  `tests/__init__.py` and a minimal pytest config) rather than inventing a different test runner
+  — see [references/architecture.md](references/architecture.md) for what to mock (TTS, torch,
+  real ffmpeg calls) so unit tests stay fast.
+
+## 5. Implementation (green)
+
+- Before writing code, plan the implementation as a sequence of small commits — think in
+  terms of the smallest set of reviewable steps that gets from red to green, not "write
+  everything, then commit once at the end". A reviewer (human or the self-review in step 7)
+  can actually follow a series of small, well-described commits; a single giant diff hides
+  where a bug was introduced and makes step 8's fixes harder to isolate.
+- Place new code according to the hexagonal layout in
+  [references/hexagonal-architecture.md](references/hexagonal-architecture.md): domain logic in
+  `domain/`, orchestration in `application/use_cases/` against `application/ports/`, and any
+  concrete library/framework code (TTS, video, audio, persistence, Tkinter) in `adapters/`. If
+  the change touches a module still living in the old flat layout (`fh/`, `models/`, `tk/`,
+  `audio_video_generator.py`), migrate that specific piece as its own early commit — see the
+  migration strategy in that reference file. Don't let an unrelated feature/fix balloon into a
+  full architecture rewrite in one PR.
+- Write the minimum code to make the unit tests pass. Never let `domain/` or `application/`
+  import a concrete library directly (`TTS`, `torch`, `cv2`, `tkinter`) — if a use case needs
+  new external behavior, add or extend a port first, then implement it in an adapter.
+- Commit as you go, one logical change per commit (e.g. "add Row validation", "extract
+  AudioProcessorPort + PydubAudioAdapter", "add speech_speed clamping") — not one commit per
+  file and not one commit for the whole feature. Keep any hexagonal-migration commit separate
+  from the feature/fix commits that motivated it. Each commit message should describe *why*,
+  not just restate the diff. Re-run `pytest tests/unit` before each commit so history doesn't
+  contain broken intermediate states.
+- Refactor only once everything is green, as its own separate commit(s) — don't mix
+  behavior changes and refactoring in the same commit.
+
+## 6. Integration tests
+
+- Location: `tests/integration/`. These exercise real module boundaries together (e.g. Task
+  persistence round-trip, or the AudioVideoGenerator wired to the real fh/ managers), stubbing
+  only the genuinely expensive/external parts (TTS model inference, GPU calls) rather than
+  mocking everything like the unit tests do.
+- Every acceptance criterion in the spec that describes an end-to-end/user-visible flow should
+  have an integration test driving it, not just isolated unit coverage.
+
+## 7. Self-review
+
+Invoke the `/code-review` skill against everything changed on this branch relative to `develop`.
+Treat its findings as required input to the next phase, not optional commentary — this is the
+last automated check before the work becomes visible to anyone else.
+
+## 8. Fix findings
+
+Apply fixes for confirmed findings, re-running unit + integration tests after each fix. If a
+finding reveals the spec itself was wrong or incomplete (not just the code), update
+`specs/<slug>.md` to match reality — the spec should remain a truthful record of what was built,
+not a stale draft of what was originally guessed.
+
+## 9. Generate PR
+
+Push the branch and open the PR with `gh pr create`, using the spec as the source for the PR
+description (link `specs/<slug>.md`, restate its acceptance criteria as a test-plan checklist).
+
+Pushing to the shared remote and opening a PR are both visible, hard-to-fully-reverse actions —
+show the user the exact push target and the full PR title/body, and get their explicit
+confirmation before running `git push` or `gh pr create`, regardless of how autonomous the rest
+of this workflow has been.
+
+## 10. Verify CI checks
+
+```bash
+gh pr checks <pr-number> --watch
+```
+
+If `--watch` isn't available, poll `gh pr checks <pr-number>` instead. On failure, pull logs
+(`gh run view --log-failed`), fix, push, and re-verify. Don't report the workflow as done while
+any check is red or still pending.

--- a/.claude/skills/dev-workflow/references/architecture.md
+++ b/.claude/skills/dev-workflow/references/architecture.md
@@ -1,0 +1,109 @@
+# podlit_py environment & architecture reference
+
+Read this when you reach the implementation phase (step 5) of the dev-workflow, or whenever
+you need to know where a change belongs or how to get the project running locally.
+
+## Environment setup
+
+The `Makefile` is the source of truth for setup — don't hand-roll `pip install` commands,
+since exact versions matter here (this stack has a history of version-sensitive breakage
+between torch, TTS, and numpy).
+
+```bash
+make install        # runs install-ffmpeg + create-env + install-deps
+```
+
+Individual targets, useful when only part of the setup is broken:
+
+- `make install-ffmpeg` — installs Homebrew (if missing) and `ffmpeg` via brew. macOS only.
+- `make create-env` — creates a conda env named `tts` on Python 3.9. TTS/torch on this
+  project pin to older, CPU-friendly versions, so this env should not be reused for
+  unrelated Python work.
+- `make install-deps` — installs, in order: `torch`/`torchaudio` (CPU wheels), `TTS==0.22.0`,
+  `opencv-python`, `pydub`, `numpy==1.26.4`. The numpy pin matters: newer numpy breaks TTS 0.22.0's
+  C extensions.
+
+Always `conda activate tts` before running anything below — the app imports `TTS.api` and
+`torch` directly, so it will fail outside this env.
+
+```bash
+make run             # python app.py
+make clean            # remove __pycache__ and .pyc files
+```
+
+## Running and debugging
+
+`make run` launches a Tkinter window (`App` in `app.py`) backed by a task queue manager.
+There's no CLI/headless mode — this is a GUI app, so if you're debugging pipeline logic
+without wanting to click through the UI, prefer writing a small throwaway script that
+imports `AudioVideoGenerator` directly rather than driving the whole window.
+
+First run will download the XTTS v2 model weights (`tts_models/multilingual/multi-dataset/xtts_v2`)
+via the `TTS` library — expect a slow first launch and make sure there's disk space and network
+access before assuming something is broken.
+
+Generated intermediate files land in `cfg.TEMP_DIR` / `cfg.OUTPUT_DIR` (`./tmp`, `./output`,
+gitignored) — check there first when debugging why a video looks wrong, before re-running the
+whole pipeline.
+
+## Architecture map (current/legacy layout)
+
+This is the layout as it exists today. The project is migrating this toward a hexagonal
+architecture — see [hexagonal-architecture.md](hexagonal-architecture.md) for the target
+package layout, and use it (not this flat map) when deciding where new code belongs.
+
+```
+app.py                        Entry point: builds AudioVideoGenerator + WindowTaskQueueManager
+audio_video_generator.py      AudioVideoGenerator: orchestrates TTS -> audio -> video per task
+pkg/config.py                 All paths/colors/sizes/FPS constants — check here before hardcoding
+fh/                            Low-level media helpers, one manager per concern:
+  haudio.py                    AudioManager — silence padding, audio-level ops
+  hvideo.py                    VideoManager — renders a video fragment from text + audio
+  hfiles.py                    FileManager — temp/output paths, work folder creation
+models/
+  task.py                      Task — a named, ordered sequence of Rows; (de)serializes to/from JSON
+  row.py                        Row — one (text, lang) pair, the atomic unit of narration
+tk/
+  window_task_queue_manager.py  Main window: owns the queue, wires UI actions to AudioVideoGenerator
+  treeview_task_queue.py        Treeview widget listing queued tasks
+```
+
+Data flow for one generation: a `Task` holds ordered `Row`s (text + language). `generate_files`
+in `audio_video_generator.py` iterates the rows, calls `TTS.tts_to_file` per row (respecting
+`speech_speed`), pads silence via `AudioManager`, renders each row as a video fragment via
+`VideoManager`, then hands off to `FileManager`/`fh` to concatenate into the final output. When
+changing this flow, keep the per-row loop language-aware — rows can alternate EN/ES within a
+single task (see the project's prompt template in `README.md`).
+
+## Working on the Tkinter UI
+
+`tk/window_task_queue_manager.py` owns queue state and wires buttons/menus to
+`AudioVideoGenerator` calls; `tk/treeview_task_queue.py` is purely the list widget. Task
+persistence (load/save queue to file, edit task name, edit rows) is JSON-based via
+`Task.build_from_string` / `Task.validate_input` in `models/task.py` — when adding a new field
+to a task, update the JSON schema there first, then the UI, not the other way around.
+
+## Testing notes specific to this repo
+
+There is no `tests/` directory or pytest config yet as of this writing — the first
+dev-workflow run that adds tests should also add a minimal `pytest.ini` (or
+`[tool.pytest.ini_options]` in `pyproject.toml`) and `tests/__init__.py`, `tests/unit/__init__.py`,
+`tests/integration/__init__.py`.
+
+Mock these in unit tests — they are slow, heavy, or require a GPU/model download:
+- `TTS.api.TTS` (and any `.tts_to_file` calls) in `audio_video_generator.py`
+- `torch.cuda.is_available()` — test both branches without needing an actual GPU
+- Real ffmpeg/moviepy video rendering in `fh/hvideo.py`
+
+Integration tests may stub only the TTS model call itself (e.g., patch `TTS.tts_to_file` to
+write a tiny silent WAV) while letting `AudioManager`, `VideoManager`, and `FileManager` run
+for real — that's what actually validates the wiring between them.
+
+## Common pitfalls
+
+- Editing dependency versions without checking why they're pinned (see numpy/TTS note above)
+  is the most common way to break this project silently.
+- Assuming CPU/GPU: `audio_video_generator.py` auto-selects `cuda` if available, else `cpu` —
+  don't assume a codepath is dead just because your machine has no GPU.
+- Adding a new constant: put it in `pkg/config.py`, not inline in `fh/` or `tk/` — that file is
+  the single place non-code-owners are expected to look for tunables (colors, sizes, FPS, paths).

--- a/.claude/skills/dev-workflow/references/hexagonal-architecture.md
+++ b/.claude/skills/dev-workflow/references/hexagonal-architecture.md
@@ -1,0 +1,143 @@
+# Hexagonal architecture (ports & adapters) for podlit_py
+
+podlit_py is migrating from its current flat layout (`fh/`, `models/`, `tk/`,
+`audio_video_generator.py` all directly importing concrete libraries like `TTS.api` and
+`tkinter`) to a hexagonal architecture. Read this whenever the implementation phase (step 5
+of the dev-workflow) touches anything beyond a trivial, purely-cosmetic change.
+
+## Why this matters here specifically
+
+Today `AudioVideoGenerator` directly imports `TTS.api.TTS` and `torch`, and `fh/hvideo.py`
+directly does the video rendering — which is exactly why unit tests for this project have to
+mock library internals instead of swapping in a fake. Hexagonal architecture fixes that at the
+root: the domain and application layers never import `TTS`, `torch`, `cv2`, or `tkinter`
+directly — they only depend on ports (interfaces) that adapters implement. Once that's true,
+unit tests use simple in-memory fakes instead of mocking third-party internals, and swapping
+the TTS engine, the video backend, or the UI toolkit becomes a matter of writing a new adapter,
+not touching business logic.
+
+## The dependency rule
+
+Dependencies only ever point inward:
+
+```
+adapters  --->  application  --->  domain
+```
+
+- **domain** knows nothing about the outside world — no imports of `TTS`, `torch`, `cv2`,
+  `tkinter`, `json`, or the filesystem. Pure Python data + business rules.
+- **application** orchestrates domain objects to fulfill use cases, talking to the outside
+  world only through **ports** (abstract interfaces) that it defines. It does not know which
+  concrete adapter is plugged in.
+- **adapters** implement ports (driven/secondary adapters: TTS engine, video renderer, audio
+  processor, file/task persistence) or drive the application (driving/primary adapters: the
+  Tkinter UI, and later a CLI if one ever exists). Adapters may import third-party libraries
+  freely — that's their entire job.
+
+If you ever need `application/` or `domain/` to import from `adapters/`, that's a sign the
+port is missing or wrong — fix the port, don't add the import.
+
+## Target package layout
+
+```
+domain/
+  task.py                    Task (was models/task.py) — pure business rules, no JSON/file I/O
+  row.py                     Row (was models/row.py)
+  exceptions.py              Domain-specific errors (e.g. InvalidRowError)
+
+application/
+  ports/
+    tts_port.py               TextToSpeechPort — synthesize(text, language, voice, speed) -> audio bytes/path
+    video_renderer_port.py     VideoRendererPort — render_fragment(audio_path, text) -> video_path
+    audio_processor_port.py    AudioProcessorPort — add_silence(audio_path, ms, ...), and similar
+    file_storage_port.py       FileStoragePort — temp/output path management, work folder creation
+    task_repository_port.py    TaskRepositoryPort — load_queue(), save_queue(tasks), by-name lookup
+  use_cases/
+    generate_media_use_case.py     GenerateMediaUseCase — replaces the orchestration currently
+                                    inline in audio_video_generator.py: iterate a Task's Rows,
+                                    call TextToSpeechPort + AudioProcessorPort + VideoRendererPort,
+                                    hand off to FileStoragePort for the final concatenated output
+    manage_task_queue_use_case.py  AddTask/EditTask/RemoveTask/ReorderTask/SaveQueue/LoadQueue —
+                                    currently scattered across tk/window_task_queue_manager.py
+
+adapters/
+  driven/                      "secondary" adapters — implement application/ports/*
+    tts/
+      coqui_tts_adapter.py       implements TextToSpeechPort using TTS.api.TTS (+ device/cuda selection)
+    video/
+      opencv_video_adapter.py    implements VideoRendererPort (current fh/hvideo.py logic)
+    audio/
+      pydub_audio_adapter.py     implements AudioProcessorPort (current fh/haudio.py logic)
+    persistence/
+      json_task_repository.py   implements TaskRepositoryPort (task queue load/save as JSON)
+    filesystem/
+      local_file_storage_adapter.py  implements FileStoragePort (current fh/hfiles.py logic)
+  driving/                     "primary" adapters — call INTO application/use_cases/*
+    ui_tkinter/
+      window_task_queue_manager.py   (moved from tk/) calls ManageTaskQueueUseCase / GenerateMediaUseCase
+      treeview_task_queue.py         (moved from tk/) — pure widget, unchanged
+
+config/
+  settings.py                 (renamed from pkg/config.py) — paths, colors, sizes, FPS constants;
+                               adapters read from here, domain/application never do
+
+app.py                        Composition root: builds concrete adapters, injects them into the
+                               use cases, wires the use cases into the driving adapter (Tkinter),
+                               and starts it. This is the ONLY file allowed to know about every
+                               concrete adapter at once.
+```
+
+## Naming conventions
+
+- Ports: abstract classes or `typing.Protocol` in `application/ports/`, suffix `Port`
+  (`TextToSpeechPort`, not `ITts` or `TtsInterface`).
+- Adapters: suffix `Adapter`, named after the concrete technology (`CoquiTTSAdapter`,
+  `JSONTaskRepository` is acceptable too — pick one convention and keep it consistent across
+  `adapters/driven/`).
+- Use cases: suffix `UseCase`, named as a verb phrase (`GenerateMediaUseCase`, not
+  `MediaService` or `MediaManager`) — a use case is one thing the application does, not a bag
+  of related methods.
+
+## Migration strategy — incremental, not a big-bang rewrite
+
+Retrofitting hexagonal architecture onto an existing codebase is itself a large change, and
+step 5 of the main workflow already requires small, well-described commits — don't turn "add
+one feature" into "also rewrite the whole architecture" in a single PR. Instead, apply the
+strangler pattern:
+
+1. When a dev-workflow run touches a module that still lives in the old flat layout, migrate
+   *only the piece it touches* into the new structure as part of that change (e.g. fixing a bug
+   in `fh/haudio.py` is the moment to introduce `AudioProcessorPort` +
+   `PydubAudioAdapter`, moving just that logic — not `fh/hvideo.py` too).
+   Do this as its own early commit in the sequence (see step 5's commit-planning guidance),
+   separate from the actual feature/fix commits.
+2. Never leave a port half-implemented — if you introduce `TextToSpeechPort`, the concrete
+   `CoquiTTSAdapter` must fully implement it in the same change; don't add an interface with
+   no real implementation behind it.
+3. Update `app.py` (the composition root) in the same commit that finishes moving a piece,
+   so the app never has a module simultaneously wired the old way and the new way.
+4. Prefer creating a new use case/port over expanding an existing one when a fix is
+   tangential — a `GenerateMediaUseCase` gaining an unrelated queue-management method is a
+   sign it should have been `ManageTaskQueueUseCase` instead.
+5. It's fine for old and new structure to coexist for a while during the migration — track
+   what's left to migrate in the spec's "Out of scope" section (see
+   [spec-template.md](spec-template.md)) so it isn't silently forgotten, rather than pretending
+   the migration is finished before it is.
+
+## Testing implications
+
+Once ports exist, unit tests (step 4 of the workflow) inject fakes that implement the port
+directly instead of mocking library internals:
+
+```python
+class FakeTTSAdapter(TextToSpeechPort):
+    def synthesize(self, text, language, voice, speed):
+        return "fake_audio.wav"
+```
+
+This is strictly better than `unittest.mock.patch("TTS.api.TTS")` — it's typed, it can't drift
+silently from the real adapter's signature, and it makes the use case's test read as "given
+this port behavior, the use case does X" rather than "given this mock call sequence...".
+Integration tests (step 6) should exercise at least one use case wired to its *real* driven
+adapters (except the genuinely expensive ones — TTS model inference, GPU calls), to confirm the
+wiring itself, not just each side in isolation.

--- a/.claude/skills/dev-workflow/references/spec-template.md
+++ b/.claude/skills/dev-workflow/references/spec-template.md
@@ -1,0 +1,32 @@
+# Spec template
+
+Save as `specs/<branch-slug>.md`. Keep it short enough to actually get read — this is a
+working contract for the tests and the self-review, not a design document to impress anyone.
+
+```markdown
+# <Title>
+
+Source: <GitHub issue URL, or "user instruction" + one-line paraphrase>
+Branch: <feature|fix>/<slug>
+
+## Problem / goal
+What's broken or missing, in 1-3 sentences. Why it matters if that's not obvious.
+
+## Scope
+What this change does and does not cover. Be explicit about the "does not" — that's what
+prevents scope creep during implementation and gives the self-review something to check against.
+
+## Acceptance criteria
+Numbered, testable statements. Every one of these should map to at least one unit or
+integration test later.
+
+1. ...
+2. ...
+
+## Edge cases / open questions
+Anything ambiguous in the source issue/instruction, resolved here after asking the user.
+If nothing was ambiguous, write "none".
+
+## Out of scope
+Explicitly excluded related work, so future readers don't wonder why it's missing.
+```


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/dev-workflow/` — a Claude Code skill encoding this project's development workflow: intake (GitHub issue or instruction) → branch → spec-first (SDD, with a mandatory confirmation stop) → TDD (unit tests before code) → implementation (small, well-described commits) → integration tests → self-review (`/code-review`) → fix findings → PR (with mandatory confirmation) → CI verification.
- Mandates a hexagonal architecture (ports & adapters) target for the codebase, with a full target package layout (`domain/`, `application/ports+use_cases/`, `adapters/driven+driving/`) and an incremental (strangler-pattern) migration strategy, defined in `references/hexagonal-architecture.md`.
- `references/architecture.md` documents the current/legacy module layout, env setup (Makefile/conda), and what to mock in tests; now points to the hexagonal reference for where new code should live.
- `references/spec-template.md` provides the spec template used in the SDD step.

## Test plan
- [ ] N/A — this PR only adds Claude Code skill/reference markdown files, no application code changes.
- [ ] Skill triggers correctly and its instructions read clearly when exercised on a real issue/instruction in a future session.