### PR TITLE
Add TTS engine adapters (Mary/eSpeak/Magpie) - final choice: MagpieTTS, prosody abandoned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           python-version: "3.9"
 
+      # espeak-ng is a native CLI binary (EspeakNGAdapter shells out to it), not a pip
+      # package - needed so its integration test can run against the real binary in CI.
+      - name: Install espeak-ng
+        run: sudo apt-get update && sudo apt-get install -y espeak-ng
+
       # Mirrors Makefile's install-deps target (minus install-ffmpeg, which this
       # runner doesn't need for imports to succeed). Needed because tests/ now
       # imports torch/TTS/pydub/opencv-python transitively via the adapters and

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: install install-ffmpeg install-deps create-env activate-env run
+.PHONY: install install-ffmpeg install-espeak-ng install-deps create-env activate-env run
 
 # Default target when 'make' is run without arguments
 all: install
 
 # Main installation target
-install: install-ffmpeg create-env install-deps
+install: install-ffmpeg install-espeak-ng create-env install-deps
 
 # Install ffmpeg using Homebrew (macOS)
 install-ffmpeg:
@@ -17,6 +17,11 @@ install-ffmpeg:
 	fi
 	@echo "Installing ffmpeg..."
 	brew install ffmpeg
+
+# Install espeak-ng (native CLI binary used by EspeakNGAdapter, not a pip package)
+install-espeak-ng:
+	@echo "Installing espeak-ng..."
+	brew install espeak-ng
 
 # Create conda environment
 create-env:
@@ -52,6 +57,7 @@ help:
 	@echo "Available targets:"
 	@echo "  install         : Install all dependencies (default)"
 	@echo "  install-ffmpeg  : Install ffmpeg using Homebrew"
+	@echo "  install-espeak-ng : Install espeak-ng using Homebrew"
 	@echo "  create-env      : Create conda environment"
 	@echo "  install-deps    : Install Python dependencies"
 	@echo "  run             : Run the application"

--- a/adapters/driven/tts/coqui_tts_adapter.py
+++ b/adapters/driven/tts/coqui_tts_adapter.py
@@ -10,10 +10,15 @@ XTTS_V2_MODEL_PATH = "tts_models/multilingual/multi-dataset/xtts_v2"
 
 
 class CoquiTTSAdapter(TextToSpeechPort):
-    """Wraps Coqui XTTS v2. XTTS v2 has no SSML input path at the model level."""
+    """Wraps Coqui XTTS v2. XTTS v2 has no SSML input path at the model level.
+
+    The voice catalog is fetched once at construction and cached - it's static for the life of
+    the process, so there's no need to re-list `voices_dir` on every synthesize() call.
+    """
 
     def __init__(self, voices_dir: str = "sample_voices"):
         self.voices_dir = voices_dir
+        self._voices = self._fetch_voices()
         device = "cuda" if torch.cuda.is_available() else "cpu"
         self.tts = TTS(XTTS_V2_MODEL_PATH, progress_bar=False).to(device)
 
@@ -29,7 +34,7 @@ class CoquiTTSAdapter(TextToSpeechPort):
         if is_ssml:
             raise SSMLNotSupportedError("CoquiTTSAdapter (XTTS v2) does not support SSML input")
 
-        if voice not in self.list_voices():
+        if voice not in self._voices:
             raise VoiceNotFoundError(f"Voice {voice!r} not found in {self.voices_dir!r}")
 
         speaker_wav = os.path.join(self.voices_dir, voice)
@@ -42,7 +47,10 @@ class CoquiTTSAdapter(TextToSpeechPort):
         )
 
     def list_voices(self) -> list[str]:
-        return [name for name in os.listdir(self.voices_dir) if name.endswith(".wav")]
+        return self._voices
 
     def supports_ssml(self) -> bool:
         return False
+
+    def _fetch_voices(self) -> list[str]:
+        return [name for name in os.listdir(self.voices_dir) if name.endswith(".wav")]

--- a/adapters/driven/tts/espeak_ng_adapter.py
+++ b/adapters/driven/tts/espeak_ng_adapter.py
@@ -1,0 +1,55 @@
+import subprocess
+
+from application.ports.tts_port import TextToSpeechPort
+from domain.exceptions import TTSEngineUnavailableError, VoiceNotFoundError
+
+DEFAULT_WORDS_PER_MINUTE = 175
+ESPEAK_NG_BINARY = "espeak-ng"
+
+
+class EspeakNGAdapter(TextToSpeechPort):
+    """Shells out to the espeak-ng CLI binary - no server/Docker needed.
+
+    Confirmed by live testing: real Spanish voices (multiple regional variants) and real SSML
+    (<speak>, <emphasis>, <break>, <prosody>) both work out of the box, unlike MaryTTSAdapter.
+    `language` is accepted (required by the port) but unused - eSpeak-NG's own voice identifiers
+    already encode language, so `voice` alone determines it.
+    """
+
+    def __init__(self, binary: str = ESPEAK_NG_BINARY):
+        self.binary = binary
+
+    def synthesize(
+        self,
+        content: str,
+        language: str,
+        voice: str,
+        speed: float,
+        output_path: str,
+        is_ssml: bool = False,
+    ) -> None:
+        if voice not in self.list_voices():
+            raise VoiceNotFoundError(f"Voice {voice!r} not found in espeak-ng's voice list")
+
+        words_per_minute = round(DEFAULT_WORDS_PER_MINUTE * speed)
+        command = [self.binary, "-v", voice, "-s", str(words_per_minute), "-w", output_path]
+        if is_ssml:
+            command.append("-m")
+        command.append(content)
+
+        try:
+            subprocess.run(command, check=True, capture_output=True)
+        except (subprocess.CalledProcessError, FileNotFoundError) as error:
+            raise TTSEngineUnavailableError(f"espeak-ng failed to synthesize: {error}") from error
+
+    def list_voices(self) -> list[str]:
+        try:
+            result = subprocess.run([self.binary, "--voices"], check=True, capture_output=True, text=True)
+        except (subprocess.CalledProcessError, FileNotFoundError) as error:
+            raise TTSEngineUnavailableError(f"espeak-ng --voices failed: {error}") from error
+
+        lines = result.stdout.strip().splitlines()[1:]  # skip the header row
+        return [line.split()[3] for line in lines if line.strip()]
+
+    def supports_ssml(self) -> bool:
+        return True

--- a/adapters/driven/tts/espeak_ng_adapter.py
+++ b/adapters/driven/tts/espeak_ng_adapter.py
@@ -48,8 +48,12 @@ class EspeakNGAdapter(TextToSpeechPort):
         except (subprocess.CalledProcessError, FileNotFoundError) as error:
             raise TTSEngineUnavailableError(f"espeak-ng --voices failed: {error}") from error
 
+        # Column 4 (File, e.g. "gmw/en-US") is what -v actually accepts - confirmed live.
+        # Column 3 (VoiceName, e.g. "English_(America)") looks like an identifier but -v
+        # rejects it ("Error: The specified espeak-ng voice does not exist"); column 1
+        # (Language, e.g. "en-us") is accepted too but isn't guaranteed unique per voice.
         lines = result.stdout.strip().splitlines()[1:]  # skip the header row
-        return [line.split()[3] for line in lines if line.strip()]
+        return [line.split()[4] for line in lines if line.strip()]
 
     def supports_ssml(self) -> bool:
         return True

--- a/adapters/driven/tts/espeak_ng_adapter.py
+++ b/adapters/driven/tts/espeak_ng_adapter.py
@@ -14,10 +14,14 @@ class EspeakNGAdapter(TextToSpeechPort):
     (<speak>, <emphasis>, <break>, <prosody>) both work out of the box, unlike MaryTTSAdapter.
     `language` is accepted (required by the port) but unused - eSpeak-NG's own voice identifiers
     already encode language, so `voice` alone determines it.
+
+    The voice catalog is fetched once at construction and cached - it's static for the life of
+    the process, so there's no need to re-spawn `espeak-ng --voices` on every synthesize() call.
     """
 
     def __init__(self, binary: str = ESPEAK_NG_BINARY):
         self.binary = binary
+        self._voices = self._fetch_voices()
 
     def synthesize(
         self,
@@ -28,13 +32,17 @@ class EspeakNGAdapter(TextToSpeechPort):
         output_path: str,
         is_ssml: bool = False,
     ) -> None:
-        if voice not in self.list_voices():
+        if voice not in self._voices:
             raise VoiceNotFoundError(f"Voice {voice!r} not found in espeak-ng's voice list")
 
         words_per_minute = round(DEFAULT_WORDS_PER_MINUTE * speed)
         command = [self.binary, "-v", voice, "-s", str(words_per_minute), "-w", output_path]
         if is_ssml:
             command.append("-m")
+        # "--" stops espeak-ng from parsing `content` as options if it happens to start with
+        # "-" (e.g. a dash-led line of dialogue) - confirmed live: without it, espeak-ng exits
+        # with "invalid option" and writes no file at all.
+        command.append("--")
         command.append(content)
 
         try:
@@ -43,6 +51,12 @@ class EspeakNGAdapter(TextToSpeechPort):
             raise TTSEngineUnavailableError(f"espeak-ng failed to synthesize: {error}") from error
 
     def list_voices(self) -> list[str]:
+        return self._voices
+
+    def supports_ssml(self) -> bool:
+        return True
+
+    def _fetch_voices(self) -> list[str]:
         try:
             result = subprocess.run([self.binary, "--voices"], check=True, capture_output=True, text=True)
         except (subprocess.CalledProcessError, FileNotFoundError) as error:
@@ -54,6 +68,3 @@ class EspeakNGAdapter(TextToSpeechPort):
         # (Language, e.g. "en-us") is accepted too but isn't guaranteed unique per voice.
         lines = result.stdout.strip().splitlines()[1:]  # skip the header row
         return [line.split()[4] for line in lines if line.strip()]
-
-    def supports_ssml(self) -> bool:
-        return True

--- a/adapters/driven/tts/magpie_tts_adapter.py
+++ b/adapters/driven/tts/magpie_tts_adapter.py
@@ -1,0 +1,65 @@
+import torch
+import torchaudio
+
+from application.ports.tts_port import TextToSpeechPort
+from domain.exceptions import SSMLNotSupportedError, VoiceNotFoundError
+
+MAGPIE_MODEL_NAME = "nvidia/magpie_tts_multilingual_357m"
+SAMPLE_RATE = 22050
+
+
+class MagpieTTSAdapter(TextToSpeechPort):
+    """Wraps NVIDIA's MagpieTTS (NeMo). Confirmed by live testing: runs on CPU (~4x slower
+    than real-time - workable for this project's background queue, not real-time use), with
+    genuine neural quality and real Spanish support.
+
+    Requires `nemo_toolkit[tts]` installed from its `main` git branch - the stable PyPI release
+    fails to load this checkpoint (tokenizer config references a locale the stable release's
+    validator rejects). This is a large (~2.2GB), unpinned dependency deliberately NOT added to
+    this project's Makefile/CI (see specs/magpie-tts-adapter.md) - install it manually:
+        pip install "nemo_toolkit[tts] @ git+https://github.com/NVIDIA-NeMo/NeMo.git"
+
+    Deliberate limitation, confirmed with the user: MagpieTTS's public API has NO prosody
+    control whatsoever - no SSML, no style/tone description, not even a numeric speed knob.
+    `speed` is accepted (required by the port) but has no effect. `is_ssml=True` raises
+    SSMLNotSupportedError.
+    """
+
+    def __init__(self, model_name: str = MAGPIE_MODEL_NAME):
+        from nemo.collections.tts.models import MagpieTTSModel
+
+        self.model = MagpieTTSModel.from_pretrained(model_name, map_location="cpu")
+        self.model = self.model.cpu()
+        self.model.eval()
+
+    def synthesize(
+        self,
+        content: str,
+        language: str,
+        voice: str,
+        speed: float,
+        output_path: str,
+        is_ssml: bool = False,
+    ) -> None:
+        if is_ssml:
+            raise SSMLNotSupportedError("MagpieTTSAdapter does not support SSML input")
+
+        if voice not in self.list_voices():
+            raise VoiceNotFoundError(f"Voice {voice!r} not found - available: {self.list_voices()}")
+
+        speaker_index = self._voice_to_speaker_index(voice)
+
+        with torch.no_grad():
+            audio, audio_len = self.model.do_tts(content, language=language, speaker_index=speaker_index)
+
+        torchaudio.save(output_path, audio[:, : audio_len[0]].cpu(), SAMPLE_RATE)
+
+    def list_voices(self) -> list[str]:
+        return [f"speaker_{i}" for i in range(self.model.num_baked_speakers)]
+
+    def supports_ssml(self) -> bool:
+        return False
+
+    @staticmethod
+    def _voice_to_speaker_index(voice: str) -> int:
+        return int(voice.removeprefix("speaker_"))

--- a/adapters/driven/tts/marytts_adapter.py
+++ b/adapters/driven/tts/marytts_adapter.py
@@ -1,0 +1,84 @@
+import urllib.error
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+from application.ports.tts_port import TextToSpeechPort
+from domain.exceptions import TTSEngineUnavailableError, VoiceNotFoundError
+
+DEFAULT_BASE_URL = "http://localhost:59125"
+
+
+class MaryTTSAdapter(TextToSpeechPort):
+    """Talks to a local MaryTTS HTTP server. Unlike Coqui, MaryTTS has real SSML support.
+
+    Plain-text speed adjustment is implemented by wrapping the content in a minimal MaryXML
+    <prosody rate="..."> envelope, since MaryTTS has no separate numeric speed parameter.
+    Caller-supplied SSML (is_ssml=True) is sent verbatim - speed is ignored in that case, since
+    rewriting arbitrary SSML to inject a rate risks corrupting it.
+    """
+
+    def __init__(self, base_url: str = DEFAULT_BASE_URL):
+        self.base_url = base_url
+
+    def synthesize(
+        self,
+        content: str,
+        language: str,
+        voice: str,
+        speed: float,
+        output_path: str,
+        is_ssml: bool = False,
+    ) -> None:
+        if voice not in self.list_voices():
+            raise VoiceNotFoundError(f"Voice {voice!r} not found on MaryTTS server at {self.base_url!r}")
+
+        if is_ssml:
+            input_type = "SSML"
+            input_text = content
+        elif speed != 1.0:
+            input_type = "SSML"
+            input_text = self._wrap_with_prosody(content, language, speed)
+        else:
+            input_type = "TEXT"
+            input_text = content
+
+        params = {
+            "INPUT_TEXT": input_text,
+            "INPUT_TYPE": input_type,
+            "OUTPUT_TYPE": "AUDIO",
+            "AUDIO": "WAVE_FILE",
+            "LOCALE": language,
+            "VOICE": voice,
+        }
+
+        try:
+            with urlopen(f"{self.base_url}/process?{urlencode(params)}") as response:
+                audio_bytes = response.read()
+        except urllib.error.URLError as error:
+            raise TTSEngineUnavailableError(f"MaryTTS server at {self.base_url!r} unreachable: {error}") from error
+
+        with open(output_path, "wb") as output_file:
+            output_file.write(audio_bytes)
+
+    def list_voices(self) -> list[str]:
+        try:
+            with urlopen(f"{self.base_url}/voices") as response:
+                body = response.read().decode("utf-8")
+        except urllib.error.URLError as error:
+            raise TTSEngineUnavailableError(f"MaryTTS server at {self.base_url!r} unreachable: {error}") from error
+
+        return [line.split()[0] for line in body.strip().splitlines() if line.strip()]
+
+    def supports_ssml(self) -> bool:
+        return True
+
+    @staticmethod
+    def _wrap_with_prosody(content: str, language: str, speed: float) -> str:
+        rate_percent = round((speed - 1.0) * 100)
+        sign = "+" if rate_percent >= 0 else ""
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            f'<maryxml version="0.5" xml:lang="{language}">'
+            f'<prosody rate="{sign}{rate_percent}%">{content}</prosody>'
+            "</maryxml>"
+        )

--- a/adapters/driven/tts/marytts_adapter.py
+++ b/adapters/driven/tts/marytts_adapter.py
@@ -3,7 +3,12 @@ from urllib.parse import urlencode
 from urllib.request import urlopen
 
 from application.ports.tts_port import TextToSpeechPort
-from domain.exceptions import LanguageNotSupportedError, TTSEngineUnavailableError, VoiceNotFoundError
+from domain.exceptions import (
+    LanguageNotSupportedError,
+    SSMLNotSupportedError,
+    TTSEngineUnavailableError,
+    VoiceNotFoundError,
+)
 
 DEFAULT_BASE_URL = "http://localhost:59125"
 
@@ -31,20 +36,22 @@ class MaryTTSAdapter(TextToSpeechPort):
     - No Spanish voice/locale exists for MaryTTS at all (see _LANGUAGE_TO_LOCALE above).
     - Genuine externally-supplied SSML (INPUT_TYPE=SSML with a <speak> root) throws a
       server-side DOMException on this image - a known, longstanding MaryTTS bug in its
-      SSML-to-MaryXML pipeline, not a bug in this adapter's request shape. supports_ssml()
-      still reports True because RAWMARYXML input (this adapter's own speed-wrapping path)
-      does work; is_ssml=True calls will raise whatever the server returns until that
-      upstream bug is fixed, so treat is_ssml=True with this adapter as unverified in practice.
+      SSML-to-MaryXML pipeline, not a bug in this adapter's request shape. `supports_ssml()`
+      reports False: only this adapter's own RAWMARYXML speed-wrapping path works, and that's
+      an internal implementation detail, not "accepts SSML input from the caller" - is_ssml=True
+      always raises SSMLNotSupportedError.
 
     Plain-text speed adjustment is implemented by wrapping the content in a minimal MaryXML
     <prosody rate="..."> envelope sent as RAWMARYXML (not SSML - MaryTTS's SSML parser expects
     genuine SSML, not pre-built MaryXML, and mixing the two throws the same DOMException above).
-    Caller-supplied SSML (is_ssml=True) is sent verbatim as INPUT_TYPE=SSML - speed is ignored
-    in that case, since rewriting arbitrary SSML to inject a rate risks corrupting it.
+
+    The voice catalog is fetched once at construction and cached - it's static for the life of
+    a MaryTTS server process, so there's no need to re-fetch it on every synthesize() call.
     """
 
     def __init__(self, base_url: str = DEFAULT_BASE_URL):
         self.base_url = base_url
+        self._voices = self._fetch_voices()
 
     def synthesize(
         self,
@@ -55,17 +62,20 @@ class MaryTTSAdapter(TextToSpeechPort):
         output_path: str,
         is_ssml: bool = False,
     ) -> None:
-        if voice not in self.list_voices():
+        if is_ssml:
+            raise SSMLNotSupportedError(
+                "MaryTTSAdapter does not support caller-supplied SSML "
+                "(genuine SSML input is broken on synesthesiam/marytts:5.2)"
+            )
+
+        if voice not in self._voices:
             raise VoiceNotFoundError(f"Voice {voice!r} not found on MaryTTS server at {self.base_url!r}")
 
         locale = _LANGUAGE_TO_LOCALE.get(language)
         if locale is None:
             raise LanguageNotSupportedError(f"MaryTTS has no locale mapping for language {language!r}")
 
-        if is_ssml:
-            input_type = "SSML"
-            input_text = content
-        elif speed != 1.0:
+        if speed != 1.0:
             input_type = "RAWMARYXML"
             input_text = self._wrap_with_prosody(content, locale, speed)
         else:
@@ -91,6 +101,12 @@ class MaryTTSAdapter(TextToSpeechPort):
             output_file.write(audio_bytes)
 
     def list_voices(self) -> list[str]:
+        return self._voices
+
+    def supports_ssml(self) -> bool:
+        return False
+
+    def _fetch_voices(self) -> list[str]:
         try:
             with urlopen(f"{self.base_url}/voices") as response:
                 body = response.read().decode("utf-8")
@@ -98,9 +114,6 @@ class MaryTTSAdapter(TextToSpeechPort):
             raise TTSEngineUnavailableError(f"MaryTTS server at {self.base_url!r} unreachable: {error}") from error
 
         return [line.split()[0] for line in body.strip().splitlines() if line.strip()]
-
-    def supports_ssml(self) -> bool:
-        return True
 
     @staticmethod
     def _wrap_with_prosody(content: str, locale: str, speed: float) -> str:

--- a/adapters/driven/tts/marytts_adapter.py
+++ b/adapters/driven/tts/marytts_adapter.py
@@ -3,18 +3,44 @@ from urllib.parse import urlencode
 from urllib.request import urlopen
 
 from application.ports.tts_port import TextToSpeechPort
-from domain.exceptions import TTSEngineUnavailableError, VoiceNotFoundError
+from domain.exceptions import LanguageNotSupportedError, TTSEngineUnavailableError, VoiceNotFoundError
 
 DEFAULT_BASE_URL = "http://localhost:59125"
 
+# Verified live against synesthesiam/marytts:5.2's /locales endpoint - English is the only
+# language in this voice set with more than one country variant (en_US/en_GB), so it needs an
+# explicit locale; the rest use their bare language code as MaryTTS's own locale identifier.
+# There is no Spanish entry: MaryTTS has never shipped an official Spanish voice (a "Jorge"
+# attempt was abandoned, unreleased) - confirmed by live testing, not just documentation.
+_LANGUAGE_TO_LOCALE = {
+    "en": "en_US",
+    "de": "de",
+    "fr": "fr",
+    "it": "it",
+    "sv": "sv",
+    "ru": "ru",
+    "tr": "tr",
+}
+
 
 class MaryTTSAdapter(TextToSpeechPort):
-    """Talks to a local MaryTTS HTTP server. Unlike Coqui, MaryTTS has real SSML support.
+    """Talks to a local MaryTTS HTTP server.
+
+    Known limitations confirmed by live testing against synesthesiam/marytts:5.2 (the only
+    published tag for this image, last updated 2020) - not just secondary-source docs:
+    - No Spanish voice/locale exists for MaryTTS at all (see _LANGUAGE_TO_LOCALE above).
+    - Genuine externally-supplied SSML (INPUT_TYPE=SSML with a <speak> root) throws a
+      server-side DOMException on this image - a known, longstanding MaryTTS bug in its
+      SSML-to-MaryXML pipeline, not a bug in this adapter's request shape. supports_ssml()
+      still reports True because RAWMARYXML input (this adapter's own speed-wrapping path)
+      does work; is_ssml=True calls will raise whatever the server returns until that
+      upstream bug is fixed, so treat is_ssml=True with this adapter as unverified in practice.
 
     Plain-text speed adjustment is implemented by wrapping the content in a minimal MaryXML
-    <prosody rate="..."> envelope, since MaryTTS has no separate numeric speed parameter.
-    Caller-supplied SSML (is_ssml=True) is sent verbatim - speed is ignored in that case, since
-    rewriting arbitrary SSML to inject a rate risks corrupting it.
+    <prosody rate="..."> envelope sent as RAWMARYXML (not SSML - MaryTTS's SSML parser expects
+    genuine SSML, not pre-built MaryXML, and mixing the two throws the same DOMException above).
+    Caller-supplied SSML (is_ssml=True) is sent verbatim as INPUT_TYPE=SSML - speed is ignored
+    in that case, since rewriting arbitrary SSML to inject a rate risks corrupting it.
     """
 
     def __init__(self, base_url: str = DEFAULT_BASE_URL):
@@ -32,12 +58,16 @@ class MaryTTSAdapter(TextToSpeechPort):
         if voice not in self.list_voices():
             raise VoiceNotFoundError(f"Voice {voice!r} not found on MaryTTS server at {self.base_url!r}")
 
+        locale = _LANGUAGE_TO_LOCALE.get(language)
+        if locale is None:
+            raise LanguageNotSupportedError(f"MaryTTS has no locale mapping for language {language!r}")
+
         if is_ssml:
             input_type = "SSML"
             input_text = content
         elif speed != 1.0:
-            input_type = "SSML"
-            input_text = self._wrap_with_prosody(content, language, speed)
+            input_type = "RAWMARYXML"
+            input_text = self._wrap_with_prosody(content, locale, speed)
         else:
             input_type = "TEXT"
             input_text = content
@@ -47,7 +77,7 @@ class MaryTTSAdapter(TextToSpeechPort):
             "INPUT_TYPE": input_type,
             "OUTPUT_TYPE": "AUDIO",
             "AUDIO": "WAVE_FILE",
-            "LOCALE": language,
+            "LOCALE": locale,
             "VOICE": voice,
         }
 
@@ -73,12 +103,12 @@ class MaryTTSAdapter(TextToSpeechPort):
         return True
 
     @staticmethod
-    def _wrap_with_prosody(content: str, language: str, speed: float) -> str:
+    def _wrap_with_prosody(content: str, locale: str, speed: float) -> str:
         rate_percent = round((speed - 1.0) * 100)
         sign = "+" if rate_percent >= 0 else ""
         return (
             '<?xml version="1.0" encoding="UTF-8"?>'
-            f'<maryxml version="0.5" xml:lang="{language}">'
+            f'<maryxml version="0.5" xml:lang="{locale}">'
             f'<prosody rate="{sign}{rate_percent}%">{content}</prosody>'
             "</maryxml>"
         )

--- a/domain/exceptions.py
+++ b/domain/exceptions.py
@@ -8,3 +8,7 @@ class VoiceNotFoundError(Exception):
 
 class TTSEngineUnavailableError(Exception):
     """Raised when a TTS engine adapter can't reach its backing service (e.g. a local server)."""
+
+
+class LanguageNotSupportedError(Exception):
+    """Raised when a requested language has no locale/voice mapping for the current engine."""

--- a/domain/exceptions.py
+++ b/domain/exceptions.py
@@ -4,3 +4,7 @@ class SSMLNotSupportedError(Exception):
 
 class VoiceNotFoundError(Exception):
     """Raised when a requested voice identifier isn't available for the current engine."""
+
+
+class TTSEngineUnavailableError(Exception):
+    """Raised when a TTS engine adapter can't reach its backing service (e.g. a local server)."""

--- a/specs/espeak-ng-adapter.md
+++ b/specs/espeak-ng-adapter.md
@@ -1,0 +1,68 @@
+# Implement EspeakNGAdapter — the actual chosen engine (supersedes MaryTTS as primary)
+
+Source: https://github.com/fxneiram/podlit_py/issues/35 (continued)
+Branch: feature/marytts-adapter
+
+## Why this exists
+
+Live testing of `MaryTTSAdapter` against a real `synesthesiam/marytts:5.2` container (the only
+published tag for that image) found two disqualifying problems for this project specifically:
+
+1. **No Spanish voice/locale exists for MaryTTS at all** — confirmed via its own `/locales`
+   endpoint, and via research showing MaryTTS never officially shipped one. This project's core
+   purpose (per `CLAUDE.md`) is bilingual EN/ES content — a TTS engine that can't do Spanish
+   fails the actual requirement, not just a nice-to-have.
+2. **Genuine SSML input is broken** on that server (a longstanding MaryTTS bug: its SSML→MaryXML
+   parser throws a `DOMException` on well-formed `<speak>` input), so the *other* reason MaryTTS
+   was chosen over Piper doesn't hold up in practice either.
+
+Given the project's explicit priority is multi-language support, and eSpeak-NG was already the
+documented fallback with (per the original #33 research) arguably broader real SSML coverage,
+this was live-tested as a direct replacement primary — and confirmed working out of the box:
+real Spanish voices (multiple regional variants: Spain, Mexico, Venezuela), real SSML
+(`<speak>`, `<emphasis>`, `<break time="...">`, `<prosody rate="...">`), no server/Docker needed
+at all (native CLI binary).
+
+`MaryTTSAdapter` stays in the codebase (bugs fixed, limitations now accurately documented) as a
+second, more limited implementation of the same port — the port design's whole point was
+supporting more than one engine without rewriting the core, and it costs nothing to leave it.
+
+## Design
+
+`EspeakNGAdapter` shells out to the `espeak-ng` CLI via `subprocess.run` with an argument list
+(never a shell string — see `coding-standards.md`'s subprocess-safety rule).
+
+- `voice`: passed directly as `-v <voice>`. eSpeak-NG's own voice identifiers already encode
+  language (e.g. `Spanish_(Latin_America)`, `en-us`), so — unlike MaryTTS/Coqui — this adapter
+  doesn't need a separate `language`→locale mapping; `language` is accepted (required by the
+  port) but not used to derive anything, since the voice already determines it.
+- `speed`: eSpeak-NG has a native words-per-minute knob (`-s <wpm>`, default 175). Converted as
+  `round(175 * speed)` — no XML-wrapping hack needed, unlike MaryTTS.
+- `is_ssml`: passing `-m` enables eSpeak-NG's own SSML/markup parser. Confirmed by live testing
+  that `-s` (rate) and `-m` (SSML, which can carry its own `<prosody rate="...">`) compose
+  without conflict — so, unlike `MaryTTSAdapter`, **this adapter does not need to silently
+  ignore `speed` when `is_ssml=True`**; both apply together as real SSML semantics intend.
+- `list_voices()`: parses `espeak-ng --voices`' `VoiceName` column (4th whitespace-separated
+  field).
+- Errors: `subprocess.CalledProcessError` (engine failed) or `FileNotFoundError` (binary missing)
+  both get wrapped as `TTSEngineUnavailableError`, consistent with the other adapters' contract.
+
+## Acceptance criteria
+
+1. `adapters/driven/tts/espeak_ng_adapter.py` defines `EspeakNGAdapter(TextToSpeechPort)` as
+   described above.
+2. Unit tests mock `subprocess.run` (fast, no real binary needed) covering: correct argument
+   list for plain text, `-m` added for SSML, speed→wpm conversion, `VoiceNotFoundError`,
+   `TTSEngineUnavailableError` on both failure modes, `/voices` parsing.
+3. **Integration test calls the real `espeak-ng` binary** — no subprocess mocking at all, since
+   it's a fast, lightweight, already-installed local tool with nothing "expensive" to stub
+   (unlike Coqui/MaryTTS). Wires the real adapter into `AudioVideoGenerator` and asserts a real,
+   valid WAV file is produced.
+4. `.github/workflows/ci.yml` installs `espeak-ng` (`apt-get install -y espeak-ng`) so that
+   integration test runs for real in CI too, not just locally.
+5. `app.py` still unchanged (still `CoquiTTSAdapter`) — the actual cutover is #37's job.
+
+## Out of scope
+
+Same as `marytts-adapter.md`: #36 (voice management UX), #37 (cutover/regression test/Makefile),
+#40 (this adapter needs none of it, which is itself worth noting in #40 when that issue starts).

--- a/specs/magpie-tts-adapter.md
+++ b/specs/magpie-tts-adapter.md
@@ -1,0 +1,81 @@
+# Implement MagpieTTSAdapter — final engine choice (prosody control abandoned)
+
+Source: https://github.com/fxneiram/podlit_py/issues/35 (continued)
+Branch: feature/marytts-adapter
+
+## Why this exists
+
+Live testing (this branch) went through three engines for #33/#35:
+
+1. **MaryTTS**: no Spanish, SSML broken on the server — ruled out.
+2. **eSpeak-NG**: real Spanish + real SSML, but voice quality is markedly robotic — kept as the
+   SSML-capable option, but the user wanted to hear real audio before committing.
+3. **MagpieTTS** (`nvidia/magpie_tts_multilingual_357m`, via NeMo): user-suggested. Live-tested
+   and confirmed: real Spanish, genuinely neural quality, and — contrary to its own
+   documentation, which says GPU is required — **it runs on CPU**, at roughly 4x slower than
+   real-time (~16-19s to generate ~4-4.5s of audio). Workable for this project's background
+   queue processing, not workable for real-time use.
+
+MagpieTTS's public API (`do_tts`) was exhaustively checked for any prosody control — SSML,
+natural-language style description (like Qwen3-TTS/Orpheus offer), even a numeric speed knob —
+and has **none**. The only controllable inputs are text, language, and a choice among a handful
+of fixed "baked" speaker voices (`model.num_baked_speakers`, confirmed = 5 on this checkpoint).
+
+**Decision, made explicitly by the user with this limitation known**: prioritize voice quality,
+accept zero prosody control. This makes Épica C (issues #26-#31, SSML/prosody) moot — its entire
+premise was having *some* mechanism to control pacing/emphasis, and the chosen engine has none.
+Those issues were closed with an explanatory comment rather than left open as misleading backlog.
+
+`MaryTTSAdapter` and `EspeakNGAdapter` (built earlier in this branch) stay in the codebase as
+documented, more-limited implementations of the same port — the port's whole point is supporting
+multiple engines without rewriting the core.
+
+## Design
+
+- **Heavy, deferred dependency.** `nemo_toolkit[tts]` must be installed from its `main` git
+  branch (the stable PyPI release's tokenizer validation is incompatible with this specific
+  checkpoint's config — confirmed by testing: `nemo_toolkit==2.7.3` fails with
+  `ValueError: Unsupported locale 'pt-BR'` on load). This is a ~2.2GB install from an unpinned,
+  actively-changing branch.
+- **Deliberately not added to `Makefile`/CI.** Unlike `torch`/`TTS`/`pydub`/`espeak-ng`, this
+  dependency is too heavy and too unstable to install on every CI run or expect in every
+  contributor's environment by default. Using `MagpieTTSAdapter` requires a manual, documented
+  install (see the adapter's own docstring) — this is an explicit, judgment-call trade-off, not
+  an oversight.
+- **Tests stub the entire `nemo` package via `sys.modules`**, rather than requiring the real
+  (huge, unstable) dependency to be installed to run the test suite. This keeps CI fast and
+  deterministic while still testing this adapter's own logic (voice↔speaker-index mapping,
+  `is_ssml` rejection, audio writing) against a controlled fake — the same reasoning as
+  `CoquiTTSAdapter`'s tests mocking `TTS.api.TTS`, just one level further out since the real
+  package isn't even installed in the test environment.
+- **Model loaded once in `__init__`** (like `CoquiTTSAdapter`, unlike the stateless
+  `MaryTTSAdapter`/`EspeakNGAdapter`) — load takes ~30s, so doing it per `synthesize()` call
+  would be prohibitive.
+- **`voice`** maps to `speaker_index` (an int 0..`num_baked_speakers - 1`); `list_voices()`
+  returns `["speaker_0", ..., f"speaker_{n-1}"]`.
+- **`speed`** is accepted (required by the port) but has no effect — there is nothing in
+  MagpieTTS's API to apply it to. Not an error; the port contract doesn't require every adapter
+  to act on every parameter (see `EspeakNGAdapter`'s unused `language`).
+- **`is_ssml=True`** raises `SSMLNotSupportedError` — same as `CoquiTTSAdapter`.
+- Output written via `torchaudio.save` (already a project dependency via `torch`/`torchaudio` —
+  no need for the extra `soundfile` package used only in this spike's throwaway test script).
+
+## Acceptance criteria
+
+1. `adapters/driven/tts/magpie_tts_adapter.py` defines `MagpieTTSAdapter(TextToSpeechPort)` as
+   above.
+2. Unit tests stub `nemo.collections.tts.models.MagpieTTSModel` via `sys.modules` — no real
+   model load, no real dependency required — covering: speaker-index mapping, `speed` being
+   accepted without effect, `SSMLNotSupportedError` on `is_ssml=True`, `VoiceNotFoundError`,
+   `list_voices()` derived from `num_baked_speakers`.
+3. Integration test wires the (still-stubbed) adapter into `AudioVideoGenerator`, same pattern
+   as the Coqui/MaryTTS wiring tests — no real model load here either, for the reasons above.
+4. `app.py` **unchanged** — cutover to any engine is #37's job, not this issue's.
+5. `Makefile`/CI **unchanged** — `nemo_toolkit` is not added as a standard dependency; the
+   adapter's docstring documents the manual install requirement.
+
+## Out of scope
+
+Épica C is closed (see above). #36 (voice management UX), #37 (cutover/regression/Makefile —
+now presumably targeting MagpieTTS given this decision), #40 (Docker — not needed for this
+engine, since it runs as a Python-in-process model, not a server).

--- a/specs/marytts-adapter.md
+++ b/specs/marytts-adapter.md
@@ -1,5 +1,25 @@
 # Implement MaryTTSAdapter for the TextToSpeechPort
 
+## Update: two assumptions below were wrong, fixed after live testing
+
+Live testing against a real `synesthesiam/marytts:5.2` container found this original design had
+two incorrect assumptions (see the "Update" section of `specs/tts-engine-spike.md` for the full
+narrative, including the bigger finding — no Spanish support at all — that this adapter's fixes
+don't change):
+
+- **`LOCALE` does not accept a bare language code.** `LOCALE=en` returns HTTP 500; only the full
+  locale (`en_US`) works. Fixed via an explicit `_LANGUAGE_TO_LOCALE` map in the adapter.
+- **`supports_ssml()` now returns `False`, not `True`.** Genuine SSML input
+  (`INPUT_TYPE=SSML` with a `<speak>` root) throws a server-side `DOMException` — a real
+  MaryTTS bug, not a request-shape mistake (tested with both a hand-built MaryXML doc and
+  genuine SSML; only `TEXT`/`RAWMARYXML` work). `is_ssml=True` now always raises
+  `SSMLNotSupportedError`, matching what `supports_ssml()` reports. The speed-adjustment
+  wrapper below was also fixed to use `INPUT_TYPE=RAWMARYXML`, not `SSML`.
+
+The rest of this document is the original design — read it for context on the speed-wrapping
+approach and error handling, but treat the two points above as superseding it where they
+disagree.
+
 Source: https://github.com/fxneiram/podlit_py/issues/35
 Branch: feature/marytts-adapter
 

--- a/specs/marytts-adapter.md
+++ b/specs/marytts-adapter.md
@@ -1,0 +1,113 @@
+# Implement MaryTTSAdapter for the TextToSpeechPort
+
+Source: https://github.com/fxneiram/podlit_py/issues/35
+Branch: feature/marytts-adapter
+
+## Problem / goal
+
+#33's spike recommended MaryTTS as the primary engine to replace Coqui XTTS v2, and #34 built
+`TextToSpeechPort` plus a `CoquiTTSAdapter` as the port's first implementation. This issue adds
+the second implementation — `MaryTTSAdapter` — talking to a local MaryTTS HTTP server, so the
+epic has a concrete alternative engine to actually validate against Coqui in #37.
+
+## Scope
+
+**Included:** `adapters/driven/tts/marytts_adapter.py` implementing `TextToSpeechPort` against
+MaryTTS's HTTP `/process`, `/voices` endpoints (documented at
+`marytts-runtime/src/main/resources/marytts/server/http/documentation.html` in the MaryTTS repo),
+using the standard-library `urllib.request` — no new pip dependency, since formalizing the
+project's dependency file is issue #39's job, not this one.
+
+**Not included, deliberately:**
+- **Not wired into `app.py`.** `app.py` keeps using `CoquiTTSAdapter` after this issue.  Per #37's
+  own description ("Solo tras validar, remover completamente la dependencia de Coqui..."), the
+  cutover happens only after the Coqui-vs-MaryTTS regression test in #37 — building the adapter
+  and switching the live engine are two different, sequenced decisions.
+- **Not standing up the MaryTTS Docker container.** That's #40. This issue assumes a MaryTTS
+  server is reachable at a configurable URL; it doesn't provision one.
+- **Not touching #36** (redefining voice selection as catalog-based) beyond what's needed for
+  `list_voices()`/`voice` to work against MaryTTS's actual voice model (which is catalog-based,
+  not cloning-based, confirming what #33/#34 already assumed).
+
+## A verification gap you should know about
+
+I don't have Docker (or any way to run a JVM server) in this environment, so I can't start a real
+MaryTTS server and confirm this adapter's HTTP calls actually work against one — only that they
+match what MaryTTS's own HTTP documentation describes. Unit/integration tests here mock the HTTP
+layer, which proves the adapter is internally consistent (right URL, right params, correct
+parsing of a *documented-shape* response) but **not** that it's wire-compatible with a real
+server. That real-world check is exactly what #37's regression test does (run the same script
+through Coqui and MaryTTS, compare), so treat this adapter as unverified-against-a-live-server
+until #37, or until you run `docker run -p 59125:59125 synesthesiam/marytts:5.2` yourself and
+smoke-test it.
+
+## API design (from MaryTTS's HTTP docs)
+
+```
+GET /process?INPUT_TEXT=...&INPUT_TYPE=TEXT|SSML&OUTPUT_TYPE=AUDIO&AUDIO=WAVE_FILE&LOCALE=...&VOICE=...
+GET /voices  -> lines of "name locale gender"
+```
+
+- `LOCALE` accepts a bare language code (e.g. `en`) per MaryTTS's own docs — no `en`→`en_US`
+  mapping table needed; `language` passes straight through as `LOCALE`.
+- `list_voices()` calls `/voices` and returns just the `name` column, in
+  `list[str]` — same shape as `CoquiTTSAdapter.list_voices()`, so `AudioVideoGenerator`/UI code
+  doesn't need to know which engine is active.
+- **`supports_ssml()` returns `True`** — this is the actual point of replacing Coqui. When
+  `is_ssml=True`, the caller's content is sent verbatim with `INPUT_TYPE=SSML`; this adapter does
+  not modify or re-wrap externally-supplied SSML.
+- **Speed, when `is_ssml=False`:** MaryTTS has no simple numeric speed knob for plain text; its
+  native rate control is the SSML `<prosody rate="+N%">` element. So when `speed != 1.0` and
+  `is_ssml=False`, this adapter wraps the plain content in a minimal MaryXML envelope itself
+  (`<maryxml>...<prosody rate="...">TEXT</prosody></maryxml>`) and sends it as `INPUT_TYPE=SSML` —
+  converting `speed` (our `[0.1, 3.0]` multiplier) to a percentage via `(speed - 1.0) * 100`
+  (e.g. `1.2` → `"+20%"`, `0.8` → `"-20%"`). When `speed == 1.0`, send `INPUT_TYPE=TEXT` plain,
+  no wrapping, since there's nothing to adjust. **This means `speed` is silently not applied when
+  `is_ssml=True`** — the port doesn't have a way to inject a rate adjustment into caller-supplied
+  SSML without risking mangling it, so this adapter assumes SSML callers encode their own desired
+  rate directly. Flag if this trade-off needs to change once #30 (SSML integration) exists.
+- **Unreachable server**: add `TTSEngineUnavailableError`, a new domain exception, raised when
+  the HTTP call fails to connect, instead of letting `urllib.error.URLError` leak through the
+  port boundary (same philosophy as `SSMLNotSupportedError`/`VoiceNotFoundError` from #34).
+
+## Naming
+
+- New domain exception: `TTSEngineUnavailableError` in `domain/exceptions.py`, raised on
+  connection failure to the MaryTTS server.
+- `MaryTTSAdapter.__init__(self, base_url: str = "http://localhost:59125")`.
+
+## Acceptance criteria
+
+1. `adapters/driven/tts/marytts_adapter.py` defines `MaryTTSAdapter(TextToSpeechPort)`:
+   - `synthesize(...)`: builds the `/process` query as described above (SSML passthrough,
+     TEXT-or-wrapped-for-speed otherwise), writes the response bytes to `output_path`.
+   - `list_voices()`: parses `/voices` into a `list[str]` of voice names.
+   - `supports_ssml()`: returns `True`.
+   - Raises `VoiceNotFoundError` if `voice` isn't in `list_voices()` (mirrors #34's
+     `CoquiTTSAdapter` contract), and `TTSEngineUnavailableError` on connection failure.
+2. `domain/exceptions.py` gains `TTSEngineUnavailableError`.
+3. Unit tests mock `urllib.request.urlopen` (or equivalent) to cover: correct query construction
+   for plain TEXT, SSML passthrough, speed-wrapped MaryXML, `VoiceNotFoundError`,
+   `TTSEngineUnavailableError` on a connection error, and `/voices` response parsing.
+4. Integration test wires the real `MaryTTSAdapter` into `AudioVideoGenerator` (same pattern as
+   #34's Coqui wiring test), with the HTTP layer stubbed at the `urllib` boundary rather than a
+   hand-written fake, to catch drift the way #34's integration test does for Coqui.
+5. `app.py` and `WindowTaskQueueManager` are **unchanged** — still wired to `CoquiTTSAdapter`.
+
+## Open questions for you to confirm
+
+1. Are you comfortable proceeding on the documented-but-unverified API shape above, given I can't
+   test against a live MaryTTS server here? Or would you rather hold this issue until you (or a
+   session with Docker access) can smoke-test a running container first?
+2. OK with stdlib `urllib.request` (no new dependency) rather than pulling in `requests`, given
+   #39 hasn't formalized the dependency file yet?
+3. OK with the speed-silently-ignored-under-SSML trade-off described above, or should
+   `synthesize` raise instead of silently ignoring `speed` when `is_ssml=True` and `speed != 1.0`?
+
+## Out of scope
+
+- #36: full redefinition of voice management UX (this issue only makes `list_voices()`/`voice`
+  work correctly against MaryTTS's catalog model).
+- #37: Makefile/Dockerfile updates, Coqui-vs-MaryTTS regression test, live-server verification,
+  and switching `app.py` to use this adapter.
+- #40: MaryTTS Docker container/compose setup.

--- a/specs/tts-engine-spike.md
+++ b/specs/tts-engine-spike.md
@@ -53,7 +53,32 @@ Two things worth flagging that change the *framing* of this decision but not the
   (`Row`/`Task` gaining an `ssml` field, issue #27) are both framed around actual SSML tags, and
   redesigning that framing is a bigger decision than this spike is scoped for.
 
-## Recommendation: MaryTTS as primary, eSpeak-NG as a documented fallback
+## Update (during #35): recommendation reversed — eSpeak-NG is now primary
+
+The recommendation below was made on paper, before either engine was actually run. During #35,
+live testing against a real `synesthesiam/marytts:5.2` container (Docker) found that MaryTTS
+fails on **both** of the reasons it was picked over Piper:
+
+- **No Spanish voice/locale exists for MaryTTS at all** — confirmed via its own `/locales`
+  endpoint (only `te, en_US, en_GB, de, fr, it, sv, ru, tr`), and via research showing MaryTTS
+  never officially released one. This is disqualifying on its own: this project's core purpose
+  is bilingual EN/ES content.
+- **Genuine SSML input throws a server-side `DOMException`** on that image — a longstanding
+  MaryTTS bug in its SSML→MaryXML pipeline, not a request-shape mistake (confirmed by testing
+  both a hand-built `<maryxml>` document and genuine `<speak>...</speak>` SSML — both fail the
+  same way; only `TEXT` and `RAWMARYXML` input types work).
+
+eSpeak-NG — installed as a native binary, no Docker/server needed at all — was live-tested as
+the replacement and passed both checks immediately: real Spanish (multiple regional voices:
+Spain, Mexico, Venezuela) and real SSML (`<speak>`, `<emphasis>`, `<break>`, `<prosody rate>`)
+both worked on the first try. See `specs/espeak-ng-adapter.md` for the adapter built from this.
+
+`MaryTTSAdapter` (built in #35 before this was discovered) stays in the codebase, bugs fixed and
+limitations now accurately documented — the port design's whole point was supporting more than
+one engine, and a second, more limited implementation costs nothing to keep. But **eSpeak-NG,
+not MaryTTS, is the recommendation for #37's cutover.**
+
+## Original recommendation (superseded, kept for context): MaryTTS as primary, eSpeak-NG as a documented fallback
 
 **MaryTTS** is the pick for the primary engine. Reasoning:
 

--- a/tests/integration/test_espeak_ng_engine_wiring.py
+++ b/tests/integration/test_espeak_ng_engine_wiring.py
@@ -1,0 +1,38 @@
+import wave
+from unittest.mock import MagicMock, patch
+
+from adapters.driven.tts.espeak_ng_adapter import EspeakNGAdapter
+from audio_video_generator import AudioVideoGenerator
+
+
+def test_audio_video_generator_drives_the_real_espeak_ng_adapter(tmp_path):
+    """Unlike the Coqui/MaryTTS wiring tests, nothing here is stubbed except the unrelated
+    audio/video managers - espeak-ng is a fast, lightweight, already-installed local binary
+    with no server or heavy model to mock, so this exercises the real subprocess call and
+    produces a real, valid WAV file.
+    """
+    with (
+        patch("audio_video_generator.AudioManager"),
+        patch("audio_video_generator.VideoManager"),
+        patch("audio_video_generator.FileManager") as mock_file_manager_cls,
+        patch("audio_video_generator.cfg.TEMP_DIR", str(tmp_path)),
+    ):
+        mock_file_manager = MagicMock()
+        mock_file_manager.generate_random_path.return_value = "task123"
+        mock_file_manager.get_final_file_names.return_value = (
+            str(tmp_path / "final.wav"),
+            str(tmp_path / "final.mp4"),
+        )
+        mock_file_manager_cls.return_value = mock_file_manager
+
+        tts_engine = EspeakNGAdapter()
+        available_voice = tts_engine.list_voices()[0]
+        generator = AudioVideoGenerator(tts_engine=tts_engine, selected_voice=available_voice, speech_speed=1.0)
+        text_to_speak = {1: {"text": "Hello world.", "language": "en"}}
+
+        generator.generate_files(text_to_speak, progress_callback=MagicMock())
+
+        generated_audio_path = tmp_path / "task123_tmp_0_a.wav"
+        assert generated_audio_path.exists()
+        with wave.open(str(generated_audio_path), "rb") as wav_file:
+            assert wav_file.getnframes() > 0

--- a/tests/integration/test_magpie_tts_engine_wiring.py
+++ b/tests/integration/test_magpie_tts_engine_wiring.py
@@ -1,0 +1,52 @@
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+from tests.unit.test_magpie_tts_adapter import FakeMagpieTTSModel
+
+
+def test_audio_video_generator_drives_the_magpie_adapter(tmp_path):
+    """Same reasoning as the MagpieTTSAdapter unit tests: nemo_toolkit is too heavy/unstable
+    to install in CI, so the entire `nemo` package is stubbed rather than mocking one real
+    call - the same pattern used for the unit tests, applied here to prove the wiring through
+    AudioVideoGenerator works too.
+    """
+    fake_module = types.ModuleType("nemo.collections.tts.models")
+    fake_module.MagpieTTSModel = FakeMagpieTTSModel
+
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "nemo": types.ModuleType("nemo"),
+                "nemo.collections": types.ModuleType("nemo.collections"),
+                "nemo.collections.tts": types.ModuleType("nemo.collections.tts"),
+                "nemo.collections.tts.models": fake_module,
+            },
+        ),
+        patch("adapters.driven.tts.magpie_tts_adapter.torchaudio.save") as mock_save,
+        patch("audio_video_generator.AudioManager"),
+        patch("audio_video_generator.VideoManager"),
+        patch("audio_video_generator.FileManager") as mock_file_manager_cls,
+        patch("audio_video_generator.cfg.TEMP_DIR", str(tmp_path)),
+    ):
+        from adapters.driven.tts.magpie_tts_adapter import MagpieTTSAdapter
+        from audio_video_generator import AudioVideoGenerator
+
+        mock_file_manager = MagicMock()
+        mock_file_manager.generate_random_path.return_value = "task123"
+        mock_file_manager.get_final_file_names.return_value = (
+            str(tmp_path / "final.wav"),
+            str(tmp_path / "final.mp4"),
+        )
+        mock_file_manager_cls.return_value = mock_file_manager
+
+        tts_engine = MagpieTTSAdapter()
+        generator = AudioVideoGenerator(tts_engine=tts_engine, selected_voice="speaker_0", speech_speed=1.0)
+        text_to_speak = {1: {"text": "Hello world.", "language": "en"}}
+
+        generator.generate_files(text_to_speak, progress_callback=MagicMock())
+
+        assert tts_engine.model.do_tts_calls[0]["transcript"] == "Hello world"
+        assert tts_engine.model.do_tts_calls[0]["speaker_index"] == 0
+        mock_save.assert_called_once()

--- a/tests/integration/test_marytts_engine_wiring.py
+++ b/tests/integration/test_marytts_engine_wiring.py
@@ -27,11 +27,10 @@ def test_audio_video_generator_drives_the_real_marytts_adapter(tmp_path):
         patch("audio_video_generator.FileManager") as mock_file_manager_cls,
         patch("audio_video_generator.cfg.TEMP_DIR", str(tmp_path)),
     ):
-        # AudioVideoGenerator.__init__ calls load_voices() (1 call to /voices), then
-        # generate_files -> synthesize() calls list_voices() again to validate the
-        # voice (2nd call to /voices) before finally calling /process.
+        # MaryTTSAdapter.__init__ fetches /voices once and caches it; AudioVideoGenerator's
+        # own load_voices() and synthesize()'s voice validation both hit that cache, so only
+        # one more call (/process) happens after construction.
         mock_urlopen.side_effect = [
-            _mock_response(VOICES_RESPONSE),
             _mock_response(VOICES_RESPONSE),
             _mock_response(b"WAV-BYTES"),
         ]
@@ -48,7 +47,7 @@ def test_audio_video_generator_drives_the_real_marytts_adapter(tmp_path):
 
         generator.generate_files(text_to_speak, progress_callback=MagicMock())
 
-        process_url = mock_urlopen.call_args_list[2].args[0]
+        process_url = mock_urlopen.call_args_list[1].args[0]
         params = {key: values[0] for key, values in parse_qs(urlparse(process_url).query).items()}
         assert params["INPUT_TEXT"] == "Hello world"
         assert params["INPUT_TYPE"] == "TEXT"

--- a/tests/integration/test_marytts_engine_wiring.py
+++ b/tests/integration/test_marytts_engine_wiring.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
+from adapters.driven.tts.marytts_adapter import MaryTTSAdapter
+from audio_video_generator import AudioVideoGenerator
+
+VOICES_RESPONSE = b"alice-hsmm en_US female\n"
+
+
+def _mock_response(body: bytes):
+    response = MagicMock()
+    response.read.return_value = body
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    return response
+
+
+def test_audio_video_generator_drives_the_real_marytts_adapter(tmp_path):
+    """Wires the real MaryTTSAdapter (not a hand-written fake) into AudioVideoGenerator to
+    catch drift between what AudioVideoGenerator calls and what the concrete adapter expects.
+    Only the HTTP boundary to the MaryTTS server is stubbed - everything else is real.
+    """
+    with (
+        patch("adapters.driven.tts.marytts_adapter.urlopen") as mock_urlopen,
+        patch("audio_video_generator.AudioManager"),
+        patch("audio_video_generator.VideoManager"),
+        patch("audio_video_generator.FileManager") as mock_file_manager_cls,
+        patch("audio_video_generator.cfg.TEMP_DIR", str(tmp_path)),
+    ):
+        # AudioVideoGenerator.__init__ calls load_voices() (1 call to /voices), then
+        # generate_files -> synthesize() calls list_voices() again to validate the
+        # voice (2nd call to /voices) before finally calling /process.
+        mock_urlopen.side_effect = [
+            _mock_response(VOICES_RESPONSE),
+            _mock_response(VOICES_RESPONSE),
+            _mock_response(b"WAV-BYTES"),
+        ]
+
+        mock_file_manager = MagicMock()
+        mock_file_manager.generate_random_path.return_value = "task123"
+        audio_path = tmp_path / "final.wav"
+        mock_file_manager.get_final_file_names.return_value = (str(audio_path), str(tmp_path / "final.mp4"))
+        mock_file_manager_cls.return_value = mock_file_manager
+
+        tts_engine = MaryTTSAdapter()
+        generator = AudioVideoGenerator(tts_engine=tts_engine, selected_voice="alice-hsmm", speech_speed=1.0)
+        text_to_speak = {1: {"text": "Hello world.", "language": "en"}}
+
+        generator.generate_files(text_to_speak, progress_callback=MagicMock())
+
+        process_url = mock_urlopen.call_args_list[2].args[0]
+        params = {key: values[0] for key, values in parse_qs(urlparse(process_url).query).items()}
+        assert params["INPUT_TEXT"] == "Hello world"
+        assert params["INPUT_TYPE"] == "TEXT"
+        assert params["LOCALE"] == "en"
+        assert params["VOICE"] == "alice-hsmm"

--- a/tests/integration/test_marytts_engine_wiring.py
+++ b/tests/integration/test_marytts_engine_wiring.py
@@ -52,5 +52,5 @@ def test_audio_video_generator_drives_the_real_marytts_adapter(tmp_path):
         params = {key: values[0] for key, values in parse_qs(urlparse(process_url).query).items()}
         assert params["INPUT_TEXT"] == "Hello world"
         assert params["INPUT_TYPE"] == "TEXT"
-        assert params["LOCALE"] == "en"
+        assert params["LOCALE"] == "en_US"
         assert params["VOICE"] == "alice-hsmm"

--- a/tests/unit/test_coqui_tts_adapter.py
+++ b/tests/unit/test_coqui_tts_adapter.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -110,3 +111,22 @@ def test_list_voices_returns_wav_filenames_from_voices_dir(mock_tts_class, no_cu
     adapter = CoquiTTSAdapter(voices_dir=str(tmp_path))
 
     assert sorted(adapter.list_voices()) == ["narrator.wav", "second.wav"]
+
+
+def test_voices_are_fetched_once_at_construction_not_per_call(mock_tts_class, no_cuda, voices_dir):
+    """The voice catalog is static for the process's lifetime - caching it in __init__ avoids
+    re-listing voices_dir on every synthesize() call in a queue of N tasks."""
+    with patch("adapters.driven.tts.coqui_tts_adapter.os.listdir", wraps=os.listdir) as mock_listdir:
+        adapter = CoquiTTSAdapter(voices_dir=voices_dir)
+        mock_listdir.assert_called_once_with(voices_dir)
+
+        adapter.synthesize(
+            content="Hello",
+            language="en",
+            voice="narrator.wav",
+            speed=1.0,
+            output_path="out.wav",
+        )
+        adapter.list_voices()
+
+        mock_listdir.assert_called_once_with(voices_dir)

--- a/tests/unit/test_espeak_ng_adapter.py
+++ b/tests/unit/test_espeak_ng_adapter.py
@@ -1,0 +1,159 @@
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from adapters.driven.tts.espeak_ng_adapter import EspeakNGAdapter
+from domain.exceptions import TTSEngineUnavailableError, VoiceNotFoundError
+
+VOICES_OUTPUT = (
+    "Pty Language       Age/Gender VoiceName          File                 Other Languages\n"
+    " 5  en-us           --/M      English_(America)  en/en-us             \n"
+    " 5  es-419          --/M      Spanish_(Latin_America) roa/es-419       \n"
+)
+
+
+@pytest.fixture
+def mock_run():
+    with patch("adapters.driven.tts.espeak_ng_adapter.subprocess.run") as mock:
+        mock.return_value = MagicMock(returncode=0)
+        yield mock
+
+
+def _voices_result():
+    return MagicMock(stdout=VOICES_OUTPUT, returncode=0)
+
+
+def test_list_voices_parses_voice_name_column(mock_run):
+    mock_run.return_value = _voices_result()
+    adapter = EspeakNGAdapter()
+
+    assert adapter.list_voices() == ["English_(America)", "Spanish_(Latin_America)"]
+    mock_run.assert_called_once_with(["espeak-ng", "--voices"], check=True, capture_output=True, text=True)
+
+
+def test_synthesize_sends_plain_text_command(mock_run):
+    mock_run.side_effect = [_voices_result(), MagicMock(returncode=0)]
+    adapter = EspeakNGAdapter()
+
+    adapter.synthesize(
+        content="Hello world",
+        language="en",
+        voice="English_(America)",
+        speed=1.0,
+        output_path="out.wav",
+    )
+
+    command = mock_run.call_args_list[1].args[0]
+    assert command == ["espeak-ng", "-v", "English_(America)", "-s", "175", "-w", "out.wav", "Hello world"]
+
+
+def test_synthesize_converts_speed_to_words_per_minute(mock_run):
+    mock_run.side_effect = [_voices_result(), MagicMock(returncode=0)]
+    adapter = EspeakNGAdapter()
+
+    adapter.synthesize(
+        content="Hello world",
+        language="en",
+        voice="English_(America)",
+        speed=1.2,
+        output_path="out.wav",
+    )
+
+    command = mock_run.call_args_list[1].args[0]
+    assert "-s" in command
+    assert command[command.index("-s") + 1] == "210"
+
+
+def test_synthesize_adds_markup_flag_for_ssml(mock_run):
+    mock_run.side_effect = [_voices_result(), MagicMock(returncode=0)]
+    adapter = EspeakNGAdapter()
+
+    adapter.synthesize(
+        content="<speak>Hello <emphasis>world</emphasis></speak>",
+        language="en",
+        voice="English_(America)",
+        speed=1.0,
+        output_path="out.wav",
+        is_ssml=True,
+    )
+
+    command = mock_run.call_args_list[1].args[0]
+    assert "-m" in command
+    assert command[-1] == "<speak>Hello <emphasis>world</emphasis></speak>"
+
+
+def test_synthesize_combines_speed_and_ssml(mock_run):
+    """Unlike MaryTTSAdapter, speed is NOT ignored under is_ssml=True - -s and -m compose
+    without conflict (confirmed by live testing against the real espeak-ng binary)."""
+    mock_run.side_effect = [_voices_result(), MagicMock(returncode=0)]
+    adapter = EspeakNGAdapter()
+
+    adapter.synthesize(
+        content="<speak>Hello</speak>",
+        language="en",
+        voice="English_(America)",
+        speed=1.4,
+        output_path="out.wav",
+        is_ssml=True,
+    )
+
+    command = mock_run.call_args_list[1].args[0]
+    assert "-m" in command
+    assert command[command.index("-s") + 1] == "245"
+
+
+def test_synthesize_raises_voice_not_found(mock_run):
+    mock_run.return_value = _voices_result()
+    adapter = EspeakNGAdapter()
+
+    with pytest.raises(VoiceNotFoundError):
+        adapter.synthesize(
+            content="Hello",
+            language="en",
+            voice="missing-voice",
+            speed=1.0,
+            output_path="out.wav",
+        )
+
+
+def test_synthesize_raises_engine_unavailable_on_process_error(mock_run):
+    mock_run.side_effect = [_voices_result(), subprocess.CalledProcessError(1, ["espeak-ng"])]
+    adapter = EspeakNGAdapter()
+
+    with pytest.raises(TTSEngineUnavailableError):
+        adapter.synthesize(
+            content="Hello",
+            language="en",
+            voice="English_(America)",
+            speed=1.0,
+            output_path="out.wav",
+        )
+
+
+def test_synthesize_raises_engine_unavailable_when_binary_missing(mock_run):
+    mock_run.side_effect = [_voices_result(), FileNotFoundError("espeak-ng not found")]
+    adapter = EspeakNGAdapter()
+
+    with pytest.raises(TTSEngineUnavailableError):
+        adapter.synthesize(
+            content="Hello",
+            language="en",
+            voice="English_(America)",
+            speed=1.0,
+            output_path="out.wav",
+        )
+
+
+def test_list_voices_raises_engine_unavailable_when_binary_missing(mock_run):
+    mock_run.side_effect = FileNotFoundError("espeak-ng not found")
+    adapter = EspeakNGAdapter()
+
+    with pytest.raises(TTSEngineUnavailableError):
+        adapter.list_voices()
+
+
+def test_supports_ssml_is_true(mock_run):
+    adapter = EspeakNGAdapter()
+
+    assert adapter.supports_ssml() is True

--- a/tests/unit/test_espeak_ng_adapter.py
+++ b/tests/unit/test_espeak_ng_adapter.py
@@ -8,8 +8,8 @@ from domain.exceptions import TTSEngineUnavailableError, VoiceNotFoundError
 
 VOICES_OUTPUT = (
     "Pty Language       Age/Gender VoiceName          File                 Other Languages\n"
-    " 5  en-us           --/M      English_(America)  en/en-us             \n"
-    " 5  es-419          --/M      Spanish_(Latin_America) roa/es-419       \n"
+    " 2  en-us           --/M      English_(America)  gmw/en-US            (en 3)\n"
+    " 5  es-419          --/M      Spanish_(Latin_America) roa/es-419       (es-mx 6)\n"
 )
 
 
@@ -24,11 +24,14 @@ def _voices_result():
     return MagicMock(stdout=VOICES_OUTPUT, returncode=0)
 
 
-def test_list_voices_parses_voice_name_column(mock_run):
+def test_list_voices_parses_file_column(mock_run):
+    """Column 4 (File), not VoiceName - `-v` rejects VoiceName values in practice
+    (confirmed against the real binary: "Error: The specified espeak-ng voice does not
+    exist"), and Language (column 1) isn't guaranteed unique per voice."""
     mock_run.return_value = _voices_result()
     adapter = EspeakNGAdapter()
 
-    assert adapter.list_voices() == ["English_(America)", "Spanish_(Latin_America)"]
+    assert adapter.list_voices() == ["gmw/en-US", "roa/es-419"]
     mock_run.assert_called_once_with(["espeak-ng", "--voices"], check=True, capture_output=True, text=True)
 
 
@@ -39,13 +42,13 @@ def test_synthesize_sends_plain_text_command(mock_run):
     adapter.synthesize(
         content="Hello world",
         language="en",
-        voice="English_(America)",
+        voice="gmw/en-US",
         speed=1.0,
         output_path="out.wav",
     )
 
     command = mock_run.call_args_list[1].args[0]
-    assert command == ["espeak-ng", "-v", "English_(America)", "-s", "175", "-w", "out.wav", "Hello world"]
+    assert command == ["espeak-ng", "-v", "gmw/en-US", "-s", "175", "-w", "out.wav", "Hello world"]
 
 
 def test_synthesize_converts_speed_to_words_per_minute(mock_run):
@@ -55,7 +58,7 @@ def test_synthesize_converts_speed_to_words_per_minute(mock_run):
     adapter.synthesize(
         content="Hello world",
         language="en",
-        voice="English_(America)",
+        voice="gmw/en-US",
         speed=1.2,
         output_path="out.wav",
     )
@@ -72,7 +75,7 @@ def test_synthesize_adds_markup_flag_for_ssml(mock_run):
     adapter.synthesize(
         content="<speak>Hello <emphasis>world</emphasis></speak>",
         language="en",
-        voice="English_(America)",
+        voice="gmw/en-US",
         speed=1.0,
         output_path="out.wav",
         is_ssml=True,
@@ -92,7 +95,7 @@ def test_synthesize_combines_speed_and_ssml(mock_run):
     adapter.synthesize(
         content="<speak>Hello</speak>",
         language="en",
-        voice="English_(America)",
+        voice="gmw/en-US",
         speed=1.4,
         output_path="out.wav",
         is_ssml=True,
@@ -125,7 +128,7 @@ def test_synthesize_raises_engine_unavailable_on_process_error(mock_run):
         adapter.synthesize(
             content="Hello",
             language="en",
-            voice="English_(America)",
+            voice="gmw/en-US",
             speed=1.0,
             output_path="out.wav",
         )
@@ -139,7 +142,7 @@ def test_synthesize_raises_engine_unavailable_when_binary_missing(mock_run):
         adapter.synthesize(
             content="Hello",
             language="en",
-            voice="English_(America)",
+            voice="gmw/en-US",
             speed=1.0,
             output_path="out.wav",
         )

--- a/tests/unit/test_espeak_ng_adapter.py
+++ b/tests/unit/test_espeak_ng_adapter.py
@@ -35,6 +35,20 @@ def test_list_voices_parses_file_column(mock_run):
     mock_run.assert_called_once_with(["espeak-ng", "--voices"], check=True, capture_output=True, text=True)
 
 
+def test_voices_are_fetched_once_at_construction_not_per_call(mock_run):
+    """The voice catalog is static for the process's lifetime - caching it in __init__ avoids
+    re-spawning `espeak-ng --voices` on every synthesize() call in a queue of N tasks."""
+    mock_run.side_effect = [_voices_result(), MagicMock(returncode=0)]
+    adapter = EspeakNGAdapter()
+
+    adapter.synthesize(content="Hello", language="en", voice="gmw/en-US", speed=1.0, output_path="out.wav")
+    adapter.list_voices()
+
+    # Only 2 calls total: the --voices fetch in __init__ and the one synthesis call - not a
+    # second --voices spawn for validation inside synthesize(), nor a third from list_voices().
+    assert mock_run.call_count == 2
+
+
 def test_synthesize_sends_plain_text_command(mock_run):
     mock_run.side_effect = [_voices_result(), MagicMock(returncode=0)]
     adapter = EspeakNGAdapter()
@@ -48,7 +62,25 @@ def test_synthesize_sends_plain_text_command(mock_run):
     )
 
     command = mock_run.call_args_list[1].args[0]
-    assert command == ["espeak-ng", "-v", "gmw/en-US", "-s", "175", "-w", "out.wav", "Hello world"]
+    assert command == ["espeak-ng", "-v", "gmw/en-US", "-s", "175", "-w", "out.wav", "--", "Hello world"]
+
+
+def test_synthesize_uses_dashdash_so_content_starting_with_dash_is_not_a_flag(mock_run):
+    """Confirmed live: without "--", espeak-ng treats a leading "-" in content as an option
+    and exits with "invalid option" instead of writing any file."""
+    mock_run.side_effect = [_voices_result(), MagicMock(returncode=0)]
+    adapter = EspeakNGAdapter()
+
+    adapter.synthesize(
+        content="-this looks like a flag",
+        language="en",
+        voice="gmw/en-US",
+        speed=1.0,
+        output_path="out.wav",
+    )
+
+    command = mock_run.call_args_list[1].args[0]
+    assert command[-2:] == ["--", "-this looks like a flag"]
 
 
 def test_synthesize_converts_speed_to_words_per_minute(mock_run):
@@ -148,15 +180,17 @@ def test_synthesize_raises_engine_unavailable_when_binary_missing(mock_run):
         )
 
 
-def test_list_voices_raises_engine_unavailable_when_binary_missing(mock_run):
+def test_construction_raises_engine_unavailable_when_binary_missing(mock_run):
+    """Fetching the voice catalog now happens eagerly at construction, so a missing binary
+    fails fast here rather than lazily on the first list_voices()/synthesize() call."""
     mock_run.side_effect = FileNotFoundError("espeak-ng not found")
-    adapter = EspeakNGAdapter()
 
     with pytest.raises(TTSEngineUnavailableError):
-        adapter.list_voices()
+        EspeakNGAdapter()
 
 
 def test_supports_ssml_is_true(mock_run):
+    mock_run.return_value = _voices_result()
     adapter = EspeakNGAdapter()
 
     assert adapter.supports_ssml() is True

--- a/tests/unit/test_magpie_tts_adapter.py
+++ b/tests/unit/test_magpie_tts_adapter.py
@@ -1,0 +1,133 @@
+"""nemo_toolkit is a ~2.2GB, unstable (@main-branch-only) dependency deliberately not added
+to this project's Makefile/CI (see specs/magpie-tts-adapter.md). These tests stub the entire
+`nemo` package tree via sys.modules so the real (huge, unstable) package is never required to
+run the test suite. MagpieTTSAdapter defers its `nemo` import to __init__, so importing the
+adapter module itself (top of this file, like every other adapter test) doesn't need the stub -
+only instantiating it does, which each test does inside the `stubbed_nemo` fixture's context.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from adapters.driven.tts.magpie_tts_adapter import MagpieTTSAdapter
+from domain.exceptions import SSMLNotSupportedError, VoiceNotFoundError
+
+
+class FakeMagpieTTSModel:
+    num_baked_speakers = 5
+
+    def __init__(self):
+        self.do_tts_calls = []
+        self.do_tts_return = (MagicMock(), MagicMock())
+
+    @classmethod
+    def from_pretrained(cls, model_name, map_location=None):
+        return cls()
+
+    def cpu(self):
+        return self
+
+    def eval(self):
+        return self
+
+    def do_tts(self, transcript, language="en", speaker_index=None):
+        self.do_tts_calls.append({"transcript": transcript, "language": language, "speaker_index": speaker_index})
+        return self.do_tts_return
+
+
+@pytest.fixture
+def stubbed_nemo():
+    fake_module = types.ModuleType("nemo.collections.tts.models")
+    fake_module.MagpieTTSModel = FakeMagpieTTSModel
+    with patch.dict(
+        sys.modules,
+        {
+            "nemo": types.ModuleType("nemo"),
+            "nemo.collections": types.ModuleType("nemo.collections"),
+            "nemo.collections.tts": types.ModuleType("nemo.collections.tts"),
+            "nemo.collections.tts.models": fake_module,
+        },
+    ):
+        yield fake_module
+
+
+@pytest.fixture
+def mock_torchaudio_save():
+    with patch("adapters.driven.tts.magpie_tts_adapter.torchaudio.save") as mock_save:
+        yield mock_save
+
+
+def test_list_voices_derived_from_num_baked_speakers(stubbed_nemo, mock_torchaudio_save):
+    adapter = MagpieTTSAdapter()
+
+    assert adapter.list_voices() == ["speaker_0", "speaker_1", "speaker_2", "speaker_3", "speaker_4"]
+
+
+def test_synthesize_maps_voice_to_speaker_index(stubbed_nemo, mock_torchaudio_save):
+    adapter = MagpieTTSAdapter()
+
+    adapter.synthesize(
+        content="Hello world",
+        language="en",
+        voice="speaker_2",
+        speed=1.0,
+        output_path="out.wav",
+    )
+
+    call = adapter.model.do_tts_calls[0]
+    assert call["transcript"] == "Hello world"
+    assert call["language"] == "en"
+    assert call["speaker_index"] == 2
+
+
+def test_synthesize_accepts_speed_without_effect(stubbed_nemo, mock_torchaudio_save):
+    """speed is required by the port but has no effect - MagpieTTS has no speed control."""
+    adapter = MagpieTTSAdapter()
+
+    adapter.synthesize(
+        content="Hello world",
+        language="en",
+        voice="speaker_0",
+        speed=2.5,
+        output_path="out.wav",
+    )
+
+    assert len(adapter.model.do_tts_calls) == 1
+
+
+def test_synthesize_raises_when_ssml_requested(stubbed_nemo, mock_torchaudio_save):
+    adapter = MagpieTTSAdapter()
+
+    with pytest.raises(SSMLNotSupportedError):
+        adapter.synthesize(
+            content="<speak>Hello</speak>",
+            language="en",
+            voice="speaker_0",
+            speed=1.0,
+            output_path="out.wav",
+            is_ssml=True,
+        )
+
+    assert adapter.model.do_tts_calls == []
+
+
+def test_synthesize_raises_voice_not_found(stubbed_nemo, mock_torchaudio_save):
+    adapter = MagpieTTSAdapter()
+
+    with pytest.raises(VoiceNotFoundError):
+        adapter.synthesize(
+            content="Hello",
+            language="en",
+            voice="speaker_99",
+            speed=1.0,
+            output_path="out.wav",
+        )
+
+
+def test_supports_ssml_is_false(stubbed_nemo, mock_torchaudio_save):
+    adapter = MagpieTTSAdapter()
+
+    assert adapter.supports_ssml() is False

--- a/tests/unit/test_marytts_adapter.py
+++ b/tests/unit/test_marytts_adapter.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 
 from adapters.driven.tts.marytts_adapter import MaryTTSAdapter
-from domain.exceptions import TTSEngineUnavailableError, VoiceNotFoundError
+from domain.exceptions import LanguageNotSupportedError, TTSEngineUnavailableError, VoiceNotFoundError
 
 VOICES_RESPONSE = b"alice-hsmm en_US female\nbits3-hsmm en_US male\n"
 
@@ -53,14 +53,17 @@ def test_synthesize_sends_plain_text_when_speed_is_default(mock_urlopen, tmp_pat
     params = _query_params(process_url)
     assert params["INPUT_TYPE"] == "TEXT"
     assert params["INPUT_TEXT"] == "Hello world"
-    assert params["LOCALE"] == "en"
+    assert params["LOCALE"] == "en_US"
     assert params["VOICE"] == "alice-hsmm"
     assert params["OUTPUT_TYPE"] == "AUDIO"
     assert params["AUDIO"] == "WAVE_FILE"
     assert output_path.read_bytes() == b"WAV-BYTES"
 
 
-def test_synthesize_wraps_ssml_prosody_when_speed_adjusted(mock_urlopen, tmp_path):
+def test_synthesize_wraps_rawmaryxml_prosody_when_speed_adjusted(mock_urlopen, tmp_path):
+    """RAWMARYXML, not SSML: MaryTTS's SSML parser expects genuine SSML and throws a
+    server-side DOMException on a pre-built MaryXML document tagged as SSML (confirmed by
+    live testing against synesthesiam/marytts:5.2)."""
     mock_urlopen.side_effect = [_mock_response(VOICES_RESPONSE), _mock_response(b"WAV-BYTES")]
     output_path = tmp_path / "out.wav"
     adapter = MaryTTSAdapter()
@@ -74,7 +77,7 @@ def test_synthesize_wraps_ssml_prosody_when_speed_adjusted(mock_urlopen, tmp_pat
     )
 
     params = _query_params(mock_urlopen.call_args_list[1].args[0])
-    assert params["INPUT_TYPE"] == "SSML"
+    assert params["INPUT_TYPE"] == "RAWMARYXML"
     assert "Hello world" in params["INPUT_TEXT"]
     assert 'rate="+20%"' in params["INPUT_TEXT"]
 
@@ -158,3 +161,20 @@ def test_supports_ssml_is_true(mock_urlopen):
     adapter = MaryTTSAdapter()
 
     assert adapter.supports_ssml() is True
+
+
+def test_synthesize_raises_language_not_supported_for_spanish(mock_urlopen, tmp_path):
+    """MaryTTS has never shipped an official Spanish voice - confirmed by live testing
+    against synesthesiam/marytts:5.2's /locales endpoint, not just secondary documentation.
+    This is a real, permanent limitation for this project's bilingual EN/ES use case."""
+    mock_urlopen.return_value = _mock_response(VOICES_RESPONSE)
+    adapter = MaryTTSAdapter()
+
+    with pytest.raises(LanguageNotSupportedError):
+        adapter.synthesize(
+            content="Hola mundo",
+            language="es",
+            voice="alice-hsmm",
+            speed=1.0,
+            output_path=str(tmp_path / "out.wav"),
+        )

--- a/tests/unit/test_marytts_adapter.py
+++ b/tests/unit/test_marytts_adapter.py
@@ -5,7 +5,12 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 
 from adapters.driven.tts.marytts_adapter import MaryTTSAdapter
-from domain.exceptions import LanguageNotSupportedError, TTSEngineUnavailableError, VoiceNotFoundError
+from domain.exceptions import (
+    LanguageNotSupportedError,
+    SSMLNotSupportedError,
+    TTSEngineUnavailableError,
+    VoiceNotFoundError,
+)
 
 VOICES_RESPONSE = b"alice-hsmm en_US female\nbits3-hsmm en_US male\n"
 
@@ -34,6 +39,26 @@ def test_list_voices_parses_names_from_response(mock_urlopen):
 
     assert adapter.list_voices() == ["alice-hsmm", "bits3-hsmm"]
     mock_urlopen.assert_called_once_with("http://localhost:59125/voices")
+
+
+def test_voices_are_fetched_once_at_construction_not_per_call(mock_urlopen, tmp_path):
+    """The voice catalog is static for the life of a MaryTTS server process - caching it in
+    __init__ avoids an HTTP round-trip on every synthesize() call in a queue of N tasks."""
+    mock_urlopen.side_effect = [_mock_response(VOICES_RESPONSE), _mock_response(b"WAV-BYTES")]
+    adapter = MaryTTSAdapter()
+
+    adapter.synthesize(
+        content="Hello",
+        language="en",
+        voice="alice-hsmm",
+        speed=1.0,
+        output_path=str(tmp_path / "out.wav"),
+    )
+    adapter.list_voices()
+
+    # Only 2 calls total: the /voices fetch in __init__ and the one /process call - not a
+    # second /voices call for validation inside synthesize(), nor a third from list_voices().
+    assert mock_urlopen.call_count == 2
 
 
 def test_synthesize_sends_plain_text_when_speed_is_default(mock_urlopen, tmp_path):
@@ -82,43 +107,25 @@ def test_synthesize_wraps_rawmaryxml_prosody_when_speed_adjusted(mock_urlopen, t
     assert 'rate="+20%"' in params["INPUT_TEXT"]
 
 
-def test_synthesize_passes_through_caller_ssml_verbatim(mock_urlopen, tmp_path):
-    mock_urlopen.side_effect = [_mock_response(VOICES_RESPONSE), _mock_response(b"WAV-BYTES")]
-    output_path = tmp_path / "out.wav"
+def test_synthesize_raises_ssml_not_supported(mock_urlopen, tmp_path):
+    """supports_ssml() is False: genuine SSML input is broken on synesthesiam/marytts:5.2
+    (confirmed by live testing), so is_ssml=True always raises rather than attempting a
+    request that's known to fail server-side."""
+    mock_urlopen.return_value = _mock_response(VOICES_RESPONSE)
     adapter = MaryTTSAdapter()
-    caller_ssml = "<speak>Hello <emphasis>world</emphasis></speak>"
 
-    adapter.synthesize(
-        content=caller_ssml,
-        language="en",
-        voice="alice-hsmm",
-        speed=1.0,
-        output_path=str(output_path),
-        is_ssml=True,
-    )
+    with pytest.raises(SSMLNotSupportedError):
+        adapter.synthesize(
+            content="<speak>Hello <emphasis>world</emphasis></speak>",
+            language="en",
+            voice="alice-hsmm",
+            speed=1.0,
+            output_path=str(tmp_path / "out.wav"),
+            is_ssml=True,
+        )
 
-    params = _query_params(mock_urlopen.call_args_list[1].args[0])
-    assert params["INPUT_TYPE"] == "SSML"
-    assert params["INPUT_TEXT"] == caller_ssml
-
-
-def test_synthesize_ignores_speed_when_caller_provides_ssml(mock_urlopen, tmp_path):
-    mock_urlopen.side_effect = [_mock_response(VOICES_RESPONSE), _mock_response(b"WAV-BYTES")]
-    output_path = tmp_path / "out.wav"
-    adapter = MaryTTSAdapter()
-    caller_ssml = "<speak>Hello</speak>"
-
-    adapter.synthesize(
-        content=caller_ssml,
-        language="en",
-        voice="alice-hsmm",
-        speed=1.5,
-        output_path=str(output_path),
-        is_ssml=True,
-    )
-
-    params = _query_params(mock_urlopen.call_args_list[1].args[0])
-    assert params["INPUT_TEXT"] == caller_ssml
+    # Only the /voices fetch from __init__ - no /process call attempted.
+    assert mock_urlopen.call_count == 1
 
 
 def test_synthesize_raises_voice_not_found(mock_urlopen, tmp_path):
@@ -135,32 +142,20 @@ def test_synthesize_raises_voice_not_found(mock_urlopen, tmp_path):
         )
 
 
-def test_synthesize_raises_engine_unavailable_on_connection_error(mock_urlopen, tmp_path):
+def test_construction_raises_engine_unavailable_on_connection_error(mock_urlopen):
+    """Fetching the voice catalog now happens eagerly at construction, so an unreachable
+    server fails fast here rather than lazily on the first synthesize() call."""
     mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
-    adapter = MaryTTSAdapter()
 
     with pytest.raises(TTSEngineUnavailableError):
-        adapter.synthesize(
-            content="Hello",
-            language="en",
-            voice="alice-hsmm",
-            speed=1.0,
-            output_path=str(tmp_path / "out.wav"),
-        )
+        MaryTTSAdapter()
 
 
-def test_list_voices_raises_engine_unavailable_on_connection_error(mock_urlopen):
-    mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+def test_supports_ssml_is_false(mock_urlopen):
+    mock_urlopen.return_value = _mock_response(VOICES_RESPONSE)
     adapter = MaryTTSAdapter()
 
-    with pytest.raises(TTSEngineUnavailableError):
-        adapter.list_voices()
-
-
-def test_supports_ssml_is_true(mock_urlopen):
-    adapter = MaryTTSAdapter()
-
-    assert adapter.supports_ssml() is True
+    assert adapter.supports_ssml() is False
 
 
 def test_synthesize_raises_language_not_supported_for_spanish(mock_urlopen, tmp_path):

--- a/tests/unit/test_marytts_adapter.py
+++ b/tests/unit/test_marytts_adapter.py
@@ -1,0 +1,160 @@
+import urllib.error
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from adapters.driven.tts.marytts_adapter import MaryTTSAdapter
+from domain.exceptions import TTSEngineUnavailableError, VoiceNotFoundError
+
+VOICES_RESPONSE = b"alice-hsmm en_US female\nbits3-hsmm en_US male\n"
+
+
+def _mock_response(body: bytes):
+    response = MagicMock()
+    response.read.return_value = body
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    return response
+
+
+@pytest.fixture
+def mock_urlopen():
+    with patch("adapters.driven.tts.marytts_adapter.urlopen") as mock:
+        yield mock
+
+
+def _query_params(url: str) -> dict:
+    return {key: values[0] for key, values in parse_qs(urlparse(url).query).items()}
+
+
+def test_list_voices_parses_names_from_response(mock_urlopen):
+    mock_urlopen.return_value = _mock_response(VOICES_RESPONSE)
+    adapter = MaryTTSAdapter()
+
+    assert adapter.list_voices() == ["alice-hsmm", "bits3-hsmm"]
+    mock_urlopen.assert_called_once_with("http://localhost:59125/voices")
+
+
+def test_synthesize_sends_plain_text_when_speed_is_default(mock_urlopen, tmp_path):
+    mock_urlopen.side_effect = [_mock_response(VOICES_RESPONSE), _mock_response(b"WAV-BYTES")]
+    output_path = tmp_path / "out.wav"
+    adapter = MaryTTSAdapter()
+
+    adapter.synthesize(
+        content="Hello world",
+        language="en",
+        voice="alice-hsmm",
+        speed=1.0,
+        output_path=str(output_path),
+    )
+
+    process_url = mock_urlopen.call_args_list[1].args[0]
+    params = _query_params(process_url)
+    assert params["INPUT_TYPE"] == "TEXT"
+    assert params["INPUT_TEXT"] == "Hello world"
+    assert params["LOCALE"] == "en"
+    assert params["VOICE"] == "alice-hsmm"
+    assert params["OUTPUT_TYPE"] == "AUDIO"
+    assert params["AUDIO"] == "WAVE_FILE"
+    assert output_path.read_bytes() == b"WAV-BYTES"
+
+
+def test_synthesize_wraps_ssml_prosody_when_speed_adjusted(mock_urlopen, tmp_path):
+    mock_urlopen.side_effect = [_mock_response(VOICES_RESPONSE), _mock_response(b"WAV-BYTES")]
+    output_path = tmp_path / "out.wav"
+    adapter = MaryTTSAdapter()
+
+    adapter.synthesize(
+        content="Hello world",
+        language="en",
+        voice="alice-hsmm",
+        speed=1.2,
+        output_path=str(output_path),
+    )
+
+    params = _query_params(mock_urlopen.call_args_list[1].args[0])
+    assert params["INPUT_TYPE"] == "SSML"
+    assert "Hello world" in params["INPUT_TEXT"]
+    assert 'rate="+20%"' in params["INPUT_TEXT"]
+
+
+def test_synthesize_passes_through_caller_ssml_verbatim(mock_urlopen, tmp_path):
+    mock_urlopen.side_effect = [_mock_response(VOICES_RESPONSE), _mock_response(b"WAV-BYTES")]
+    output_path = tmp_path / "out.wav"
+    adapter = MaryTTSAdapter()
+    caller_ssml = "<speak>Hello <emphasis>world</emphasis></speak>"
+
+    adapter.synthesize(
+        content=caller_ssml,
+        language="en",
+        voice="alice-hsmm",
+        speed=1.0,
+        output_path=str(output_path),
+        is_ssml=True,
+    )
+
+    params = _query_params(mock_urlopen.call_args_list[1].args[0])
+    assert params["INPUT_TYPE"] == "SSML"
+    assert params["INPUT_TEXT"] == caller_ssml
+
+
+def test_synthesize_ignores_speed_when_caller_provides_ssml(mock_urlopen, tmp_path):
+    mock_urlopen.side_effect = [_mock_response(VOICES_RESPONSE), _mock_response(b"WAV-BYTES")]
+    output_path = tmp_path / "out.wav"
+    adapter = MaryTTSAdapter()
+    caller_ssml = "<speak>Hello</speak>"
+
+    adapter.synthesize(
+        content=caller_ssml,
+        language="en",
+        voice="alice-hsmm",
+        speed=1.5,
+        output_path=str(output_path),
+        is_ssml=True,
+    )
+
+    params = _query_params(mock_urlopen.call_args_list[1].args[0])
+    assert params["INPUT_TEXT"] == caller_ssml
+
+
+def test_synthesize_raises_voice_not_found(mock_urlopen, tmp_path):
+    mock_urlopen.return_value = _mock_response(VOICES_RESPONSE)
+    adapter = MaryTTSAdapter()
+
+    with pytest.raises(VoiceNotFoundError):
+        adapter.synthesize(
+            content="Hello",
+            language="en",
+            voice="missing-voice",
+            speed=1.0,
+            output_path=str(tmp_path / "out.wav"),
+        )
+
+
+def test_synthesize_raises_engine_unavailable_on_connection_error(mock_urlopen, tmp_path):
+    mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+    adapter = MaryTTSAdapter()
+
+    with pytest.raises(TTSEngineUnavailableError):
+        adapter.synthesize(
+            content="Hello",
+            language="en",
+            voice="alice-hsmm",
+            speed=1.0,
+            output_path=str(tmp_path / "out.wav"),
+        )
+
+
+def test_list_voices_raises_engine_unavailable_on_connection_error(mock_urlopen):
+    mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+    adapter = MaryTTSAdapter()
+
+    with pytest.raises(TTSEngineUnavailableError):
+        adapter.list_voices()
+
+
+def test_supports_ssml_is_true(mock_urlopen):
+    adapter = MaryTTSAdapter()
+
+    assert adapter.supports_ssml() is True


### PR DESCRIPTION
Closes #35

## Summary — final state after extensive live testing (3 engine pivots)

This PR went through MaryTTS → eSpeak-NG → MagpieTTS as live testing repeatedly found real, concrete problems with each prior choice. Final state, confirmed with the user:

- **MagpieTTSAdapter** (new): the chosen primary engine going forward. `nvidia/magpie_tts_multilingual_357m` via NeMo — confirmed by live testing to run on CPU (contrary to its own docs saying GPU is required), genuinely neural quality, real Spanish support. **Trade-off, explicitly accepted by the user**: its public API has zero prosody control (no SSML, no style description, not even a speed knob) — only text, language, and a choice among 5 fixed speaker voices.
- **Because of that trade-off, Épica C (issues #26-#31, SSML/prosody) is now moot** and was closed with an explanatory comment on each — their entire premise depended on having *some* prosody control mechanism, and the chosen engine has none.
- **MaryTTSAdapter** and **EspeakNGAdapter** (built earlier in this branch, both bugs fixed and live-verified) stay in the codebase as documented, more-limited implementations of the same `TextToSpeechPort` — the port's whole point was supporting multiple engines without rewriting the core.
- `app.py` still unchanged (still `CoquiTTSAdapter`) — cutover is #37's job.

## Why nemo_toolkit isn't in Makefile/CI
`nemo_toolkit[tts]` must be installed from its `main` git branch (~2.2GB, unpinned) — the stable PyPI release fails to even load this checkpoint (`ValueError: Unsupported locale 'pt-BR'`, a version-skew bug). This is too heavy/unstable to add as a standard dependency or CI step. `MagpieTTSAdapter`'s tests stub the entire `nemo` package via `sys.modules` rather than requiring the real dependency — manual install is documented in the adapter's own docstring for anyone who wants to actually use it.

## Test plan
- [x] `pytest tests/` — 43 passed across all three adapters' unit + integration tests.
- [x] `ruff check`/`ruff format --check`/`mypy` clean on all touched/new files.
- [x] Manually verified all three adapters against real backends: MaryTTS (live Docker container), eSpeak-NG (real binary, audio shared with user), MagpieTTS (real model downloaded and run on CPU, English + Spanish audio shared with user).
- [x] Security review (`/security-review`) run after each engine's addition — no findings across all three.