### PR TITLE
Config-driven TTS engine selection + Coqui-vs-MagpieTTS regression test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-ffmpeg install-espeak-ng install-deps create-env activate-env run
+.PHONY: install install-ffmpeg install-espeak-ng install-deps install-magpie create-env activate-env run
 
 # Default target when 'make' is run without arguments
 all: install
@@ -41,6 +41,19 @@ install-deps:
 	pip install numpy==1.26.4
 	@echo "\nDependencies installed successfully!"
 
+# Optional: install MagpieTTSAdapter's dependency (nvidia/magpie_tts_multilingual_357m via
+# NeMo). NOT part of `make install` - nemo_toolkit is a large (~2.2GB), unpinned install from
+# its main git branch (the stable PyPI release fails to load this specific model checkpoint),
+# too heavy/unstable to force on every install. Run this yourself, then set TTS_ENGINE=magpie
+# to use it (see pkg/config.py) - the default TTS_ENGINE (coqui) never needs this.
+# torchcodec is also required: a fresh, unpinned torchaudio moved its .save() default backend
+# to require it (confirmed while running the #37 regression test) - without it, synthesize()
+# fails with "ImportError: TorchCodec is required for save_with_torchcodec".
+install-magpie:
+	@echo "Installing nemo_toolkit from its main branch (large, unpinned - this will take a while)..."
+	pip install "nemo_toolkit[tts] @ git+https://github.com/NVIDIA-NeMo/NeMo.git"
+	pip install torchcodec
+
 # Run the application
 run:
 	@echo "Running the application..."
@@ -60,6 +73,7 @@ help:
 	@echo "  install-espeak-ng : Install espeak-ng using Homebrew"
 	@echo "  create-env      : Create conda environment"
 	@echo "  install-deps    : Install Python dependencies"
+	@echo "  install-magpie  : Install MagpieTTS's nemo_toolkit dependency (optional, not part of 'install')"
 	@echo "  run             : Run the application"
 	@echo "  clean           : Clean up temporary files"
 	@echo "  help            : Show this help message"

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ install-deps:
 # torchcodec is also required: a fresh, unpinned torchaudio moved its .save() default backend
 # to require it (confirmed while running the #37 regression test) - without it, synthesize()
 # fails with "ImportError: TorchCodec is required for save_with_torchcodec".
+# WARNING: nemo_toolkit's own unpinned requirements can upgrade the pinned CPU torch/torchaudio
+# (and possibly numpy==1.26.4) that `install-deps` set up for Coqui/eSpeak-NG. Run this in a
+# separate conda env/venv from your main `tts` env unless you're fine with those upgrading.
 install-magpie:
 	@echo "Installing nemo_toolkit from its main branch (large, unpinned - this will take a while)..."
 	pip install "nemo_toolkit[tts] @ git+https://github.com/NVIDIA-NeMo/NeMo.git"

--- a/adapters/driven/tts/magpie_tts_adapter.py
+++ b/adapters/driven/tts/magpie_tts_adapter.py
@@ -13,11 +13,13 @@ class MagpieTTSAdapter(TextToSpeechPort):
     than real-time - workable for this project's background queue, not real-time use), with
     genuine neural quality and real Spanish support.
 
-    Requires `nemo_toolkit[tts]` installed from its `main` git branch - the stable PyPI release
-    fails to load this checkpoint (tokenizer config references a locale the stable release's
-    validator rejects). This is a large (~2.2GB), unpinned dependency deliberately NOT added to
-    this project's Makefile/CI (see specs/magpie-tts-adapter.md) - install it manually:
-        pip install "nemo_toolkit[tts] @ git+https://github.com/NVIDIA-NeMo/NeMo.git"
+    Requires `nemo_toolkit[tts]` (from its `main` git branch - the stable PyPI release fails to
+    load this checkpoint) and `torchcodec` (a fresh, unpinned `torchaudio` needs it for
+    `.save()`). This is a large (~2.2GB), unpinned dependency deliberately NOT added to this
+    project's Makefile/CI (see specs/magpie-tts-adapter.md) - use `make install-magpie`, ideally
+    in a separate conda env/venv from your main `tts` env: nemo_toolkit's own unpinned
+    requirements can upgrade the CPU-pinned torch/torchaudio (and possibly numpy==1.26.4) that
+    `make install-deps` set up for Coqui/eSpeak-NG.
 
     Deliberate limitation, confirmed with the user: MagpieTTS's public API has NO prosody
     control whatsoever - no SSML, no style/tone description, not even a numeric speed knob.

--- a/app.py
+++ b/app.py
@@ -1,15 +1,26 @@
 import tkinter as tk
 
 from adapters.driven.tts.coqui_tts_adapter import CoquiTTSAdapter
+from adapters.driven.tts.magpie_tts_adapter import MagpieTTSAdapter
+from application.ports.tts_port import TextToSpeechPort
 from audio_video_generator import AudioVideoGenerator
+from pkg import config as cfg
 from tk.window_task_queue_manager import WindowTaskQueueManager
+
+
+def build_tts_engine(engine_name: str) -> TextToSpeechPort:
+    if engine_name == "coqui":
+        return CoquiTTSAdapter()
+    if engine_name == "magpie":
+        return MagpieTTSAdapter()
+    raise ValueError(f"Unknown TTS_ENGINE {engine_name!r} (expected 'coqui' or 'magpie')")
 
 
 class App:
     def __init__(self, root):
         self.root = root
 
-        tts_engine = CoquiTTSAdapter()
+        tts_engine = build_tts_engine(cfg.TTS_ENGINE)
         media_generator = AudioVideoGenerator(tts_engine=tts_engine)
         self.task_queue_app = WindowTaskQueueManager(self.root, media_generator)
 

--- a/pkg/config.py
+++ b/pkg/config.py
@@ -1,8 +1,8 @@
 import os
 
 # FOLDER PATHS
-TEMP_DIR = os.getcwd() + '/tmp'
-OUTPUT_DIR = os.getcwd() + '/output'
+TEMP_DIR = os.getcwd() + "/tmp"
+OUTPUT_DIR = os.getcwd() + "/output"
 
 # COLORS
 BACKGROUND_COLOR = (0, 0, 0)
@@ -17,3 +17,8 @@ FONT_SIZE = 80
 # MEDIA
 DURATION_BETWEEN_FRAGMENTS = 0  # ms
 FPS = 24
+
+# TTS ENGINE
+# "coqui" (default, always available) or "magpie" (requires nemo_toolkit installed separately -
+# see `make install-magpie` - not part of the default install).
+TTS_ENGINE = os.environ.get("TTS_ENGINE", "coqui")

--- a/specs/magpie-cutover-regression.md
+++ b/specs/magpie-cutover-regression.md
@@ -1,0 +1,80 @@
+# Cutover to MagpieTTS: regression test, Makefile, and removing Coqui
+
+Source: https://github.com/fxneiram/podlit_py/issues/37
+Branch: feature/magpie-cutover-regression
+
+## Problem / goal
+
+This is the final step of Épica D: validate MagpieTTS against Coqui XTTS v2 with a real,
+side-by-side comparison (not just isolated live tests, which is all that's happened so far),
+update the Makefile/dependencies for the new engine, wire `app.py` to actually use it, and only
+then consider removing Coqui.
+
+## Scope, resolved with the user
+
+**Makefile**: add a separate, clearly-optional `make install-magpie` target — not part of the
+default `make install` chain — so the Makefile documents the install without forcing
+`nemo_toolkit`'s ~2.2GB/unpinned `@main`-branch cost on every contributor or CI run.
+
+**No hard cutover.** Rather than switching `app.py` to build `MagpieTTSAdapter` outright, engine
+selection becomes **config-driven**: a `TTS_ENGINE` setting (env var, default `"coqui"`) that
+`app.py` reads to decide which adapter to build. Coqui stays the default (unchanged behavior for
+anyone not opting in); setting `TTS_ENGINE=magpie` switches to `MagpieTTSAdapter` for the
+regression comparison and any future full cutover — without deleting or disabling either engine.
+This directly enables running the regression test by toggling one config value instead of
+editing code, and defers "remove Coqui" indefinitely until it's a deliberate, separate decision.
+
+## Plan
+
+1. **Regression test**: generate the same script (a few EN + ES lines, matching this project's
+   real bilingual use case) through both `CoquiTTSAdapter` and `MagpieTTSAdapter` for real (not
+   mocked) — reusing the throwaway-venv approach from #35's live testing, since `nemo_toolkit`
+   isn't installed in this repo's normal env. Compare: perceived quality (share both audio sets
+   with the user, as done in #35), wall-clock generation time, and document known differences
+   (voice catalog size/style, language coverage, latency) in this spec.
+2. **Config-driven engine selection**: add `TTS_ENGINE` to `pkg/config.py` (env var, default
+   `"coqui"`); `app.py` builds `CoquiTTSAdapter()` or `MagpieTTSAdapter()` based on it. The
+   `MagpieTTSAdapter`/`nemo_toolkit` import only happens on the `magpie` branch, so the default
+   `coqui` path never requires `nemo_toolkit` to be installed.
+3. **Makefile**: add `install-magpie` as described above.
+4. **No removal of Coqui** in this PR or as a planned next step — both engines stay
+   permanently selectable via `TTS_ENGINE`.
+
+## Regression test results
+
+Generated the same 4 lines (2 English, 2 Spanish — matching this project's alternating
+bilingual format) through both `CoquiTTSAdapter` and `MagpieTTSAdapter` for real, using a
+throwaway venv for MagpieTTS (`nemo_toolkit` isn't installed in this repo's normal env, per the
+decision above). Audio shared with the user directly for a by-ear comparison.
+
+**Timing** (CPU, this machine, single voice, no warmup beyond model load):
+
+| Line | Coqui XTTS v2 | MagpieTTS |
+|---|---|---|
+| EN 1 | 8.2s | ~17s (log-derived) |
+| EN 2 | 7.2s | 17.3s |
+| ES 1 | 10.5s | 20.9s |
+| ES 2 | 8.1s | 19.3s |
+| **Total (4 lines)** | **34.0s** | **76.1s** |
+
+MagpieTTS is roughly **2-2.5x slower than Coqui** on this machine's CPU for equivalent short
+lines — both are well within "acceptable for background queue processing," but this is a real,
+measurable cost of the quality trade-off, not just a theoretical one.
+
+**A third dependency-fragility bug found during this test** (on top of the two already fixed in
+#35/PR #48 — the `spacy`/`bangla` Python-3.9 incompatibilities for Coqui's own install, and the
+locale/tokenizer version-skew requiring `nemo_toolkit@main`): a **freshly-installed**
+`torchaudio` (no version pin) has moved `torchaudio.save`'s default backend to require the
+separate `torchcodec` package — without it, `MagpieTTSAdapter.synthesize` fails with
+`ImportError: TorchCodec is required for save_with_torchcodec`. Installing `torchcodec`
+resolved it. This is exactly the kind of unpinned-version instability the earlier decision to
+keep `nemo_toolkit` out of the standard Makefile/CI was meant to avoid — it reinforces that
+choice rather than changing it, but `make install-magpie`'s docstring/README guidance should
+mention `torchcodec` explicitly so the next person hitting this doesn't have to re-diagnose it.
+
+## Out of scope
+
+#36 (voice management UX redesign — the existing UI already works generically against
+`list_voices()`/`change_voice()` regardless of engine, per the port design; #36 is about making
+voice selection friendlier, not a blocker here). #40 (Docker — MagpieTTS runs in-process, no
+server needed).

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+
+import pytest
+
+from app import build_tts_engine
+
+
+def test_build_tts_engine_defaults_to_coqui():
+    with patch("app.CoquiTTSAdapter") as mock_coqui_cls:
+        engine = build_tts_engine("coqui")
+
+    mock_coqui_cls.assert_called_once_with()
+    assert engine == mock_coqui_cls.return_value
+
+
+def test_build_tts_engine_selects_magpie():
+    with patch("app.MagpieTTSAdapter") as mock_magpie_cls:
+        engine = build_tts_engine("magpie")
+
+    mock_magpie_cls.assert_called_once_with()
+    assert engine == mock_magpie_cls.return_value
+
+
+def test_build_tts_engine_raises_on_unknown_engine():
+    with pytest.raises(ValueError):
+        build_tts_engine("unknown-engine")

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -5,7 +5,9 @@ import pytest
 from app import build_tts_engine
 
 
-def test_build_tts_engine_defaults_to_coqui():
+def test_build_tts_engine_selects_coqui():
+    """Tests dispatch on an explicit "coqui" argument - not the *default* resolution of
+    TTS_ENGINE itself, which is covered separately in tests/unit/test_config.py."""
     with patch("app.CoquiTTSAdapter") as mock_coqui_cls:
         engine = build_tts_engine("coqui")
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,17 @@
+import importlib
+
+from pkg import config as cfg
+
+
+def test_tts_engine_defaults_to_coqui_when_env_var_unset(monkeypatch):
+    monkeypatch.delenv("TTS_ENGINE", raising=False)
+    importlib.reload(cfg)
+
+    assert cfg.TTS_ENGINE == "coqui"
+
+
+def test_tts_engine_honors_env_var_override(monkeypatch):
+    monkeypatch.setenv("TTS_ENGINE", "magpie")
+    importlib.reload(cfg)
+
+    assert cfg.TTS_ENGINE == "magpie"


### PR DESCRIPTION
Closes #37

## Summary
- Adds `TTS_ENGINE` (env var, default `"coqui"`) to `pkg/config.py` and `build_tts_engine()` in `app.py` — selects `CoquiTTSAdapter` or `MagpieTTSAdapter`. **No hard cutover and no removal of Coqui**, per explicit confirmation: both engines stay permanently available and selectable via config. `MagpieTTSAdapter` imports safely at module top level (its `nemo_toolkit` import is deferred to `__init__`), so the default `coqui` path never needs `nemo_toolkit` installed.
- Adds `make install-magpie` (optional, **not** part of `make install`) for `nemo_toolkit`'s ~2.2GB/unpinned install — consistent with the earlier decision (#35/PR #48) to keep this heavy, unstable dependency out of the standard install/CI.
- **Regression test** (`specs/magpie-cutover-regression.md`): generated the same 4 lines (2 EN, 2 ES) through both engines for real, not mocked. MagpieTTS is ~2-2.5x slower than Coqui on CPU (76.1s vs 34.0s total) — both acceptable for this project's background queue processing. Audio shared directly with the user for a by-ear quality comparison.
- **A third dependency-fragility bug found and fixed**: a freshly-installed, unpinned `torchaudio` requires the separate `torchcodec` package for `.save()` to work at all — added to `make install-magpie` and documented in the spec, so the next person hitting this doesn't have to re-diagnose it.

## Test plan
- [x] `pytest tests/` — 48 passed.
- [x] `ruff check`/`ruff format --check`/`mypy` clean on touched files.
- [x] Manually ran the regression test end-to-end (both engines, real audio, real timings) and shared results with the user.
- [x] Security review (`/security-review`) — no findings; `TTS_ENGINE` is dispatched through a hardcoded if/elif, not `eval`/dynamic import.