### PR TITLE
Formalize dependencies: requirements.txt + requirements-dev.txt

### DIFF
--- a/.claude/skills/dev-workflow/references/architecture.md
+++ b/.claude/skills/dev-workflow/references/architecture.md
@@ -19,9 +19,13 @@ Individual targets, useful when only part of the setup is broken:
 - `make create-env` — creates a conda env named `tts` on Python 3.9. TTS/torch on this
   project pin to older, CPU-friendly versions, so this env should not be reused for
   unrelated Python work.
-- `make install-deps` — installs, in order: `torch`/`torchaudio` (CPU wheels), `TTS==0.22.0`,
-  `opencv-python`, `pydub`, `numpy==1.26.4`. The numpy pin matters: newer numpy breaks TTS 0.22.0's
-  C extensions.
+- `make install-deps` — resolves `requirements.txt` in a single `pip install -r` call:
+  `torch`/`torchaudio` (CPU wheels), `TTS==0.22.0`, `opencv-python==4.11.0.86`, `pydub`,
+  `numpy==1.22.0`. The numpy pin matters and is exact for a reason: `TTS==0.22.0` itself
+  declares `numpy==1.22.0` as a hard dependency (confirmed by trying to resolve any other numpy
+  version alongside it — pip's resolver rejects it outright), and `opencv-python>=4.12.0.88`
+  requires `numpy>=2`, which is why that package is pinned below its own latest release too.
+  See `requirements.txt`'s comments for the full reasoning.
 
 Always `conda activate tts` before running anything below — the app imports `TTS.api` and
 `torch` directly, so it will fail outside this env.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,29 +21,12 @@ jobs:
       - name: Install espeak-ng
         run: sudo apt-get update && sudo apt-get install -y espeak-ng
 
-      # Mirrors Makefile's install-deps target (minus install-ffmpeg, which this
-      # runner doesn't need for imports to succeed). Needed because tests/ now
-      # imports torch/TTS/pydub/opencv-python transitively via the adapters and
-      # fh/ modules under test.
-      - name: Install project dependencies
-        run: |
-          pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
-          # TTS==0.22.0's transitive dependencies keep releasing Python-3.10-only
-          # versions without declaring it in package metadata (pip can't skip them
-          # automatically the way it does for well-behaved packages like thinc), so
-          # they break at import time rather than at install time. Pin each one to
-          # the last version known to work on this project's pinned Python 3.9.
-          pip install "spacy<3.8"
-          # bangla 0.0.3-0.0.5 (all released the same day) also carry the bool|None
-          # syntax - only 0.0.1/0.0.2 (2017/2018) predate it.
-          pip install "bangla<0.0.3"
-          pip install TTS==0.22.0
-          pip install opencv-python
-          pip install pydub
-          pip install numpy==1.26.4
-
-      - name: Install dev tools
-        run: pip install ruff mypy pytest
+      # requirements-dev.txt pins production deps (torch/TTS/opencv-python/pydub/numpy, plus
+      # the spacy/bangla transitive-dependency pins TTS==0.22.0 needs on Python 3.9) and dev
+      # tools (ruff/mypy/pytest) together, resolved in one pass - see requirements.txt for why
+      # each pin exists.
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
 
       # Advisory for now: the legacy codebase predates these standards (see
       # references/coding-standards.md in the dev-workflow skill). Flip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,9 @@ normal pytest way once tests exist: `pytest tests/unit/test_foo.py::test_bar`.
 every PR into `develop` — `ruff`/`mypy` are advisory for now since the legacy code predates
 these standards (see `coding-standards.md` below), `pytest` is blocking.
 
-Dependency versions are pinned deliberately (`torch`/`torchaudio` CPU wheels, `TTS==0.22.0`,
-`numpy==1.26.4`) — newer numpy breaks TTS 0.22.0's C extensions. Don't bump these without reason.
+Dependency versions are pinned deliberately in `requirements.txt` (`torch`/`torchaudio` CPU
+wheels, `TTS==0.22.0`, `numpy==1.22.0` — `TTS==0.22.0` declares this exact numpy version as its
+own dependency; anything else fails `pip`'s resolver outright). Don't bump these without reason.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-ffmpeg install-espeak-ng install-deps install-magpie create-env activate-env run
+.PHONY: install install-ffmpeg install-espeak-ng install-deps install-dev-deps install-magpie create-env activate-env run
 
 # Default target when 'make' is run without arguments
 all: install
@@ -30,15 +30,19 @@ create-env:
 	@echo "\nTo activate the environment, run:"
 	@echo "  conda activate tts"
 
-# Install Python dependencies
+# Install Python dependencies (see requirements.txt for pinned versions and why they're pinned)
 install-deps:
 	@echo "Installing Python dependencies..."
 	pip install --upgrade pip
-	pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
-	pip install TTS==0.22.0
-	pip install opencv-python
-	pip install pydub
-	pip install numpy==1.26.4
+	pip install -r requirements.txt
+	@echo "\nDependencies installed successfully!"
+
+# Install dependencies plus dev tools (ruff/mypy/pytest) - for contributors, not part of
+# `make install` (running the app doesn't need lint/test tools)
+install-dev-deps:
+	@echo "Installing Python dependencies (including dev tools)..."
+	pip install --upgrade pip
+	pip install -r requirements-dev.txt
 	@echo "\nDependencies installed successfully!"
 
 # Optional: install MagpieTTSAdapter's dependency (nvidia/magpie_tts_multilingual_357m via
@@ -50,8 +54,9 @@ install-deps:
 # to require it (confirmed while running the #37 regression test) - without it, synthesize()
 # fails with "ImportError: TorchCodec is required for save_with_torchcodec".
 # WARNING: nemo_toolkit's own unpinned requirements can upgrade the pinned CPU torch/torchaudio
-# (and possibly numpy==1.26.4) that `install-deps` set up for Coqui/eSpeak-NG. Run this in a
-# separate conda env/venv from your main `tts` env unless you're fine with those upgrading.
+# (and possibly numpy - see requirements.txt) that `install-deps` set up for Coqui/eSpeak-NG.
+# Run this in a separate conda env/venv from your main `tts` env unless you're fine with those
+# upgrading.
 install-magpie:
 	@echo "Installing nemo_toolkit from its main branch (large, unpinned - this will take a while)..."
 	pip install "nemo_toolkit[tts] @ git+https://github.com/NVIDIA-NeMo/NeMo.git"
@@ -76,6 +81,7 @@ help:
 	@echo "  install-espeak-ng : Install espeak-ng using Homebrew"
 	@echo "  create-env      : Create conda environment"
 	@echo "  install-deps    : Install Python dependencies"
+	@echo "  install-dev-deps : Install Python dependencies plus dev tools (ruff/mypy/pytest)"
 	@echo "  install-magpie  : Install MagpieTTS's nemo_toolkit dependency (optional, not part of 'install')"
 	@echo "  run             : Run the application"
 	@echo "  clean           : Clean up temporary files"

--- a/adapters/driven/tts/magpie_tts_adapter.py
+++ b/adapters/driven/tts/magpie_tts_adapter.py
@@ -18,8 +18,8 @@ class MagpieTTSAdapter(TextToSpeechPort):
     `.save()`). This is a large (~2.2GB), unpinned dependency deliberately NOT added to this
     project's Makefile/CI (see specs/magpie-tts-adapter.md) - use `make install-magpie`, ideally
     in a separate conda env/venv from your main `tts` env: nemo_toolkit's own unpinned
-    requirements can upgrade the CPU-pinned torch/torchaudio (and possibly numpy==1.26.4) that
-    `make install-deps` set up for Coqui/eSpeak-NG.
+    requirements can upgrade the CPU-pinned torch/torchaudio (and possibly numpy==1.22.0 - see
+    requirements.txt) that `make install-deps` set up for Coqui/eSpeak-NG.
 
     Deliberate limitation, confirmed with the user: MagpieTTS's public API has NO prosody
     control whatsoever - no SSML, no style/tone description, not even a numeric speed knob.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+
+ruff==0.16.0
+mypy==1.11.2
+pytest==7.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,20 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.8.0
+torchaudio==2.8.0
+
+# TTS==0.22.0's own transitive dependencies keep releasing Python-3.10-only versions without
+# declaring it in package metadata (confirmed the hard way in #35/PR #48) - pin them ahead of
+# TTS so this resolves consistently instead of drifting to whatever's "latest" today.
+spacy<3.8
+bangla<0.0.3
+TTS==0.22.0
+
+# TTS==0.22.0 itself pins numpy==1.22.0 (exact) for python_version<=3.10 - pip's resolver
+# rejects any other numpy version here (confirmed: numpy==1.26.4, this Makefile's previous
+# pin, is NOT actually TTS's own requirement - it only "worked" before because the Makefile
+# installed numpy last, silently overriding whatever TTS's install had already set up).
+# opencv-python>=4.12.0.88 requires numpy>=2 on Python >=3.9, incompatible with numpy 1.x
+# entirely - 4.11.0.86 is the newest version still compatible with numpy==1.22.0.
+opencv-python==4.11.0.86
+pydub==0.25.1
+numpy==1.22.0

--- a/specs/formalize-dependencies.md
+++ b/specs/formalize-dependencies.md
@@ -1,0 +1,91 @@
+# Formalize dependencies: requirements.txt + requirements-dev.txt
+
+Source: https://github.com/fxneiram/podlit_py/issues/39
+Branch: feature/formalize-dependencies
+
+## Problem / goal
+
+`Makefile`'s `install-deps` runs five separate, unpinned `pip install` commands. This "works"
+today only because of **install order**, and the real conflict underneath it is worse than it
+looks: `opencv-python` (as currently resolved, unpinned) requires `numpy>=2`, while
+`TTS==0.22.0` itself declares an **exact** `numpy==1.22.0` dependency for `python_version<=3.10`
+— not `numpy==1.26.4` as the Makefile's own comment claimed. Confirmed by actually trying to
+resolve `numpy==1.26.4` alongside `TTS==0.22.0` in a single `pip install`: pip's resolver
+rejects it outright (`ResolutionImpossible` — "tts 0.22.0 depends on numpy==1.22.0"). The
+Makefile's sequential installs papered over this by installing whatever numpy version was
+specified *last*, silently overriding both `opencv-python`'s and `TTS`'s own declared
+requirements — not a real, resolvable dependency set, and not even the version TTS itself asks
+for.
+
+## Design
+
+**`requirements.txt` + `requirements-dev.txt`, not `pyproject.toml` dependencies.** `torch`/
+`torchaudio` need the CPU wheel index (`--extra-index-url https://download.pytorch.org/whl/cpu`)
+— `requirements.txt` supports that directive natively; PEP 621's `[project.dependencies]` in
+`pyproject.toml` has no clean per-package index equivalent. `pyproject.toml` keeps its existing
+job (tool config for ruff/mypy/pytest); dependency *versions* live in these two files.
+
+**All production dependencies resolved together, in one `pip install -r requirements.txt` call**
+— this is what actually fixes the underlying problem, not just documents it. Verified real,
+current version pins (checked against what actually installs cleanly on this project's Python
+3.9 target — see "Version pins" below) rather than repeating whatever happened to already be
+installed on someone's machine:
+
+- **`numpy==1.22.0`**, not `1.26.4`. `TTS==0.22.0` declares this exact version as its own
+  dependency for `python_version<=3.10` — this is what actually gets used to build/import its
+  C extensions, not whatever the Makefile happened to install last. Verified by installing the
+  full `requirements.txt` in a real Python 3.9 venv and running this project's entire test
+  suite (50 tests, including the real Coqui/XTTS-v2 integration test) against it — all green,
+  no regression from the `1.26.4` → `1.22.0` change.
+- **`opencv-python==4.11.0.86`** (not the latest, `5.0.0.93`) — confirmed by checking each
+  version's PyPI metadata: `4.12.0.88` and later require `numpy>=2`, incompatible with numpy 1.x
+  entirely; `4.11.0.86` is the newest version still compatible with `numpy==1.22.0`.
+- **`torch==2.8.0` / `torchaudio==2.8.0`** — the exact versions this project's own CI already
+  resolves to on Python 3.9 (confirmed from a real, green CI run's install log), now pinned
+  instead of left to "whatever's latest today."
+- **`spacy<3.8` / `bangla<0.0.3`** — the two Python-3.9-incompatibility pins already discovered
+  the hard way in #35/PR #48 (spacy's newer releases need Python ≥3.10; bangla 0.0.3+ uses
+  `bool | None` syntax that TypeErrors on 3.9), now formalized as part of the single dependency
+  file instead of living only as CI-specific `pip install` steps.
+- **`TTS==0.22.0`**, **`pydub==0.25.1`** — already-known/verified pins.
+
+**Dev tools pinned too** (`requirements-dev.txt`, `-r requirements.txt` plus `ruff`/`mypy`/
+`pytest`), to the versions already validated throughout this session's work (`ruff==0.16.0`,
+`mypy==1.11.2`, `pytest==7.4.4`) rather than "whatever's latest" — CI and local dev currently
+resolve these independently and can drift (CI has been resolving a newer `pytest` than what's
+used locally).
+
+**Makefile and CI updated to use these files** — `make install-deps` becomes
+`pip install -r requirements.txt`; a new `make install-dev-deps` target uses
+`requirements-dev.txt` (for contributors, not part of `make install` since running the app
+doesn't need lint/test tools); CI's "Install project dependencies" + "Install dev tools" steps
+collapse into one `pip install -r requirements-dev.txt`.
+
+## Local validation
+
+`brew install python@3.9 python-tk@3.9` to get a real Python 3.9 interpreter locally (this
+project's Python 3.12 sandbox default can't validate `TTS==0.22.0`, which doesn't support
+≥3.12) — then, in a fresh venv: `pip install -r requirements.txt` resolved cleanly in one pass
+(no `ResolutionImpossible`), and the full test suite (50 tests, `ruff`, `mypy`) passed against
+it. This is real, not just "should work on paper" — the numpy version change alone
+(`1.26.4` → `1.22.0`) was worth verifying against the actual Coqui/XTTS-v2 integration test,
+not just assumed safe.
+
+## Acceptance criteria
+
+1. `requirements.txt`: production deps with verified, compatible pins (including the
+   `spacy`/`bangla` transitive-dependency pins), resolvable in a single `pip install -r` call.
+2. `requirements-dev.txt`: `-r requirements.txt` plus pinned `ruff`/`mypy`/`pytest`.
+3. `Makefile`'s `install-deps` target uses `pip install -r requirements.txt`; new
+   `install-dev-deps` target uses `requirements-dev.txt`.
+4. `.github/workflows/ci.yml`'s dependency-install steps use `requirements-dev.txt` (one step
+   instead of the previous six separate `pip install` commands).
+5. `espeak-ng`/`ffmpeg` (system binaries, not pip packages) and `nemo_toolkit` (deliberately
+   excluded, per #35/#37) are unaffected — this issue is about the pip-installable dependency
+   set only.
+6. CI passes with the new, unified install.
+
+## Out of scope
+
+Docker/`requirements.txt` for a web backend (#40 — no backend exists yet). Splitting
+`pkg/config.py` or any other non-dependency-management refactor.


### PR DESCRIPTION
Closes #39

## Summary
- Adds `requirements.txt` (production deps) and `requirements-dev.txt` (adds pinned `ruff`/`mypy`/`pytest`) — replacing `Makefile`'s five separate, unpinned `pip install` commands that only "worked" via install order.
- **Found and fixed a real, deeper conflict than expected**: the Makefile's own comment claimed `numpy==1.26.4` was needed for `TTS==0.22.0`'s C extensions, but `TTS==0.22.0` actually declares an **exact** `numpy==1.22.0` dependency for `python_version<=3.10`. Confirmed by trying to resolve `numpy==1.26.4` alongside `TTS==0.22.0` in one `pip install` — pip's resolver rejects it outright (`ResolutionImpossible`). The Makefile's sequential installs papered over this by installing whatever numpy version was specified *last*.
- All version pins verified against real, current PyPI metadata (not copied from whatever happened to already be installed): `numpy==1.22.0`, `opencv-python==4.11.0.86` (4.12.0.88+ requires `numpy>=2`, incompatible with numpy 1.x), `torch`/`torchaudio==2.8.0` (this project's own CI's actual resolved version), `spacy<3.8`/`bangla<0.0.3` (the Python-3.9-incompatibility pins found in #35/PR #48).
- `Makefile`'s `install-deps` now uses `requirements.txt`; new `install-dev-deps` target uses `requirements-dev.txt`. CI's separate dependency/dev-tool install steps collapse into one `pip install -r requirements-dev.txt`.

## How this was validated
Installed a real Python 3.9 locally (`brew install python@3.9 python-tk@3.9` — this repo's Python 3.12 sandbox default can't test `TTS==0.22.0`, which doesn't support ≥3.12) and, in a fresh venv: `pip install -r requirements.txt` resolved cleanly in one pass, then the **entire test suite (50 tests) passed against it**, including the real Coqui/XTTS-v2 integration test — confirming the `numpy` `1.26.4`→`1.22.0` change doesn't regress anything.

## Test plan
- [x] `pip install -r requirements.txt` resolves in one pass on a real Python 3.9 venv (no `ResolutionImpossible`).
- [x] Full test suite (50 tests) + `ruff`/`mypy` pass against the new pins.
- [x] Security review (`/security-review`) — no findings; dependency/CI plumbing only, no new code paths.
- [ ] CI green with the new unified install (verifying now).