### PR TITLE
Add unit tests for models/task.py, fh/hfiles.py, fh/haudio.py

### DIFF
--- a/fh/haudio.py
+++ b/fh/haudio.py
@@ -1,7 +1,7 @@
-import subprocess
+import logging
 
 from pydub import AudioSegment
-from tqdm import tqdm
+
 from pkg import config as cfg
 
 
@@ -18,7 +18,7 @@ class AudioManager:
             combined += segment + silence
 
         combined.export(output_path, format="wav")
-        print(f"Combined audio exported to: {output_path}")
+        logging.info("Combined audio exported to: %s", output_path)
 
     def add_silence(self, audio_path, duration, fps, before=True, after=True):
         audio = AudioSegment.from_wav(audio_path)

--- a/models/task.py
+++ b/models/task.py
@@ -40,19 +40,20 @@ class Task:
     def validate_input(text):
         try:
             parsed_text = ast.literal_eval(text)
-            if not isinstance(parsed_text, dict):
-                raise ValueError("Input must be a dictionary.")
+        except (ValueError, SyntaxError) as e:
+            raise ValueError(f"Input is not a valid Python literal: {e}") from e
 
-            for key, value in parsed_text.items():
-                if not isinstance(key, int):
-                    raise ValueError(f"Key {key} is not an integer.")
-                if "text" not in value or "language" not in value:
-                    raise ValueError(f"Entry {key} is incorrectly formatted.")
-                if not isinstance(value["text"], str) or not isinstance(value["language"], str):
-                    raise ValueError(f"'text' or 'language' in {key} are not strings.")
-            return parsed_text
-        except Exception as e:
-            return e
+        if not isinstance(parsed_text, dict):
+            raise ValueError("Input must be a dictionary.")
+
+        for key, value in parsed_text.items():
+            if not isinstance(key, int):
+                raise ValueError(f"Key {key} is not an integer.")
+            if "text" not in value or "language" not in value:
+                raise ValueError(f"Entry {key} is incorrectly formatted.")
+            if not isinstance(value["text"], str) or not isinstance(value["language"], str):
+                raise ValueError(f"'text' or 'language' in {key} are not strings.")
+        return parsed_text
 
     def __repr__(self):
         return f"Task(name={self.name!r}, index={self.index!r}, rows={self.rows})"

--- a/models/task.py
+++ b/models/task.py
@@ -49,7 +49,7 @@ class Task:
         for key, value in parsed_text.items():
             if not isinstance(key, int):
                 raise ValueError(f"Key {key} is not an integer.")
-            if "text" not in value or "language" not in value:
+            if not isinstance(value, dict) or "text" not in value or "language" not in value:
                 raise ValueError(f"Entry {key} is incorrectly formatted.")
             if not isinstance(value["text"], str) or not isinstance(value["language"], str):
                 raise ValueError(f"'text' or 'language' in {key} are not strings.")

--- a/specs/unit-tests-models-fh.md
+++ b/specs/unit-tests-models-fh.md
@@ -1,0 +1,66 @@
+# Unit tests for models/task.py, fh/hfiles.py, fh/haudio.py
+
+Source: https://github.com/fxneiram/podlit_py/issues/41
+Branch: feature/unit-tests-models-fh
+
+## Problem / goal
+
+`models/task.py`, `models/row.py`, `fh/hfiles.py`, and `fh/haudio.py` have zero test coverage —
+all of this session's earlier test work covered the TTS port/adapters and `AudioVideoGenerator`,
+not these older, still-untouched modules. This issue closes that gap for the pieces its own
+scope names: `models/task.py`, `fh/hfiles.py`, `fh/haudio.py`.
+
+## Scope adjustment
+
+The issue's original scope also asks for "tests de integración para los endpoints de la API
+(cola de tareas, generación de contenido con OpenAI mockeado)" — there are no API endpoints yet
+(Épica A/B haven't started), so that part is deferred until those epics exist. "Mock del motor
+TTS en tests" is already done extensively across this session's earlier work (all four adapters).
+
+## Two real bugs found while adding coverage — fixed as part of this issue, not left for later
+
+Per `coding-standards.md`'s own "fix a module's instances as you touch it" policy, and since
+both were already specifically named as anti-patterns in that document:
+
+1. **`Task.validate_input` returns the exception instead of raising it** (`models/task.py:54`).
+   Its only caller (`tk/window_task_queue_manager.py`'s `btn_action_add_from_file`) already
+   wraps the call in `try/except Exception` — today, a validation failure returns an `Exception`
+   object that gets passed straight to `self.tree.add_task(...)` as if it were valid task data,
+   which then raises a *second*, unrelated `TypeError` when `add_task` tries to treat the
+   exception object like a dict. The user sees a confusing type error instead of the actual
+   validation message. Raising directly lets the existing `try/except` catch it correctly and
+   show the real error — a strict improvement, not just cleanup.
+2. **`AudioManager.combine_audio_fragments` uses `print()`** instead of `logging`
+   (`fh/haudio.py:21`) — inconsistent with the `logging` already set up in
+   `audio_video_generator.py`. Fixed while adding this file's first tests.
+
+## Testing approach
+
+- `models/task.py`/`models/row.py`: pure logic, no I/O — straightforward unit tests.
+- `fh/hfiles.py`: filesystem operations against `tmp_path`, no mocking needed (fast, real disk
+  I/O on temp dirs).
+- `fh/haudio.py`: generates small **real** silent WAV files via `pydub` (already a project
+  dependency) rather than mocking pydub itself — verifies the actual frame-boundary-padding math
+  and concatenation behavior for real, similar to this session's "don't mock what's cheap and
+  real" approach for `EspeakNGAdapter`'s integration test.
+
+## Acceptance criteria
+
+1. `tests/unit/test_task.py`: `Task.build_from_string` (valid input, invalid JSON, non-dict
+   entries, missing text/language keys) and `Task.validate_input` (valid input, non-dict,
+   non-integer keys, missing/wrong-typed fields) — the latter now raising, not returning.
+2. `tests/unit/test_row.py`: trivial construction/repr coverage.
+3. `tests/unit/test_hfiles.py`: `sanitize_filename` (special characters stripped, spaces to
+   underscores, edge case of a filename that sanitizes to empty), `get_final_file_names`,
+   `generate_random_path` (length, charset), `create_work_folders`/`clean_temp_folders` against
+   `tmp_path`.
+4. `tests/unit/test_haudio.py`: `add_silence` (padding added before/after, frame-boundary
+   rounding), `combine_audio_fragments` (output duration reflects inputs + inter-fragment
+   silence), using real small WAV files generated via `pydub.AudioSegment.silent(...)`.
+5. `models/task.py` and `fh/haudio.py` source fixes described above land alongside their tests.
+
+## Out of scope
+
+API/integration tests (no API exists yet — deferred to whichever issue actually builds Épica
+A's endpoints). `fh/hvideo.py` (heavier — real `cv2`/`PIL`/`ffmpeg` rendering; not named in this
+issue's scope, left for a future, separately-scoped pass).

--- a/tests/unit/test_haudio.py
+++ b/tests/unit/test_haudio.py
@@ -1,0 +1,83 @@
+from pydub import AudioSegment
+
+from fh.haudio import AudioManager
+from pkg import config as cfg
+
+
+def _silent_wav(path, duration_ms):
+    AudioSegment.silent(duration=duration_ms).export(str(path), format="wav")
+    return path
+
+
+def test_add_silence_pads_before_and_after(tmp_path):
+    audio_path = _silent_wav(tmp_path / "test.wav", 1000)
+    manager = AudioManager()
+
+    manager.add_silence(str(audio_path), duration=250, fps=24, before=True, after=True)
+
+    result = AudioSegment.from_wav(str(audio_path))
+    assert len(result) >= 1000 + 250 + 250
+
+
+def test_add_silence_only_before_is_shorter_than_both(tmp_path):
+    only_before_path = _silent_wav(tmp_path / "before.wav", 1000)
+    both_path = _silent_wav(tmp_path / "both.wav", 1000)
+    manager = AudioManager()
+
+    manager.add_silence(str(only_before_path), duration=250, fps=24, before=True, after=False)
+    manager.add_silence(str(both_path), duration=250, fps=24, before=True, after=True)
+
+    only_before_result = AudioSegment.from_wav(str(only_before_path))
+    both_result = AudioSegment.from_wav(str(both_path))
+    assert len(only_before_result) >= 1000 + 250
+    assert len(only_before_result) < len(both_result)
+
+
+def test_add_silence_neither_before_nor_after_only_pads_to_frame_boundary(tmp_path):
+    audio_path = _silent_wav(tmp_path / "test.wav", 1003)
+    manager = AudioManager()
+
+    manager.add_silence(str(audio_path), duration=250, fps=24, before=False, after=False)
+
+    result = AudioSegment.from_wav(str(audio_path))
+    # No before/after silence requested - only frame-boundary rounding should have grown it,
+    # so it should stay close to the original duration, not grow by the full 250ms twice.
+    assert 1003 <= len(result) < 1003 + 100
+
+
+def test_add_silence_result_is_aligned_to_frame_boundary(tmp_path):
+    fps = 24
+    frame_duration_ms = 1000 / fps
+    audio_path = _silent_wav(tmp_path / "test.wav", 1003)
+    manager = AudioManager()
+
+    manager.add_silence(str(audio_path), duration=0, fps=fps, before=False, after=False)
+
+    result = AudioSegment.from_wav(str(audio_path))
+    remainder = len(result) % frame_duration_ms
+    assert remainder < 1 or (frame_duration_ms - remainder) < 1
+
+
+def test_combine_audio_fragments_concatenates_all_inputs(tmp_path):
+    frag1 = _silent_wav(tmp_path / "frag1.wav", 500)
+    frag2 = _silent_wav(tmp_path / "frag2.wav", 700)
+    output_path = tmp_path / "combined.wav"
+    manager = AudioManager()
+
+    manager.combine_audio_fragments([str(frag1), str(frag2)], str(output_path))
+
+    result = AudioSegment.from_wav(str(output_path))
+    expected_duration = cfg.DURATION_BETWEEN_FRAGMENTS * 3 + 500 + 700
+    assert abs(len(result) - expected_duration) <= 5
+
+
+def test_combine_audio_fragments_with_single_fragment(tmp_path):
+    frag = _silent_wav(tmp_path / "frag.wav", 400)
+    output_path = tmp_path / "combined.wav"
+    manager = AudioManager()
+
+    manager.combine_audio_fragments([str(frag)], str(output_path))
+
+    result = AudioSegment.from_wav(str(output_path))
+    expected_duration = cfg.DURATION_BETWEEN_FRAGMENTS * 2 + 400
+    assert abs(len(result) - expected_duration) <= 5

--- a/tests/unit/test_haudio.py
+++ b/tests/unit/test_haudio.py
@@ -58,7 +58,12 @@ def test_add_silence_result_is_aligned_to_frame_boundary(tmp_path):
     assert remainder < 1 or (frame_duration_ms - remainder) < 1
 
 
-def test_combine_audio_fragments_concatenates_all_inputs(tmp_path):
+def test_combine_audio_fragments_concatenates_all_inputs(tmp_path, monkeypatch):
+    """DURATION_BETWEEN_FRAGMENTS is 0 in this project's actual config, which would make this
+    assertion pass identically whether the silence-insertion loop ran 0, 1, or N times - so a
+    non-zero gap is patched in here specifically to make the inter-fragment silence count
+    something this test can actually fail on."""
+    monkeypatch.setattr(cfg, "DURATION_BETWEEN_FRAGMENTS", 100)
     frag1 = _silent_wav(tmp_path / "frag1.wav", 500)
     frag2 = _silent_wav(tmp_path / "frag2.wav", 700)
     output_path = tmp_path / "combined.wav"
@@ -67,11 +72,12 @@ def test_combine_audio_fragments_concatenates_all_inputs(tmp_path):
     manager.combine_audio_fragments([str(frag1), str(frag2)], str(output_path))
 
     result = AudioSegment.from_wav(str(output_path))
-    expected_duration = cfg.DURATION_BETWEEN_FRAGMENTS * 3 + 500 + 700
+    expected_duration = 100 * 3 + 500 + 700  # one leading silence + one trailing per fragment
     assert abs(len(result) - expected_duration) <= 5
 
 
-def test_combine_audio_fragments_with_single_fragment(tmp_path):
+def test_combine_audio_fragments_with_single_fragment(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg, "DURATION_BETWEEN_FRAGMENTS", 100)
     frag = _silent_wav(tmp_path / "frag.wav", 400)
     output_path = tmp_path / "combined.wav"
     manager = AudioManager()
@@ -79,5 +85,5 @@ def test_combine_audio_fragments_with_single_fragment(tmp_path):
     manager.combine_audio_fragments([str(frag)], str(output_path))
 
     result = AudioSegment.from_wav(str(output_path))
-    expected_duration = cfg.DURATION_BETWEEN_FRAGMENTS * 2 + 400
+    expected_duration = 100 * 2 + 400
     assert abs(len(result) - expected_duration) <= 5

--- a/tests/unit/test_hfiles.py
+++ b/tests/unit/test_hfiles.py
@@ -1,0 +1,104 @@
+import os
+import string
+
+from fh.hfiles import FileManager
+
+
+def test_sanitize_filename_strips_reserved_characters():
+    manager = FileManager(temp_dir="unused", output_dir="unused")
+
+    result = manager.sanitize_filename('Title: "A Story" <Part 1> / \\ | ? *')
+
+    assert result == "Title_A_Story_Part_1_____"
+
+
+def test_sanitize_filename_replaces_spaces_with_underscores():
+    manager = FileManager(temp_dir="unused", output_dir="unused")
+
+    assert manager.sanitize_filename("Hello World") == "Hello_World"
+
+
+def test_sanitize_filename_can_produce_empty_string():
+    """Edge case worth documenting, not fixing here: a title made entirely of reserved
+    characters sanitizes to an empty string, so get_final_file_names would produce a bare
+    ".wav"/".mp4" - a real but pre-existing limitation, out of scope for this test-coverage pass."""
+    manager = FileManager(temp_dir="unused", output_dir="unused")
+
+    assert manager.sanitize_filename("???") == ""
+
+
+def test_get_final_file_names_builds_wav_and_mp4_paths(tmp_path):
+    manager = FileManager(temp_dir=str(tmp_path / "tmp"), output_dir=str(tmp_path / "output"))
+
+    audio_path, video_path = manager.get_final_file_names("My Book: Chapter 1")
+
+    assert audio_path == str(tmp_path / "output" / "My_Book_Chapter_1.wav")
+    assert video_path == str(tmp_path / "output" / "My_Book_Chapter_1.mp4")
+
+
+def test_generate_random_path_has_expected_length_and_charset():
+    manager = FileManager(temp_dir="unused", output_dir="unused")
+
+    result = manager.generate_random_path(length=12)
+
+    assert len(result) == 12
+    assert all(char in string.ascii_letters + string.digits for char in result)
+
+
+def test_generate_random_path_default_length_is_ten():
+    manager = FileManager(temp_dir="unused", output_dir="unused")
+
+    assert len(manager.generate_random_path()) == 10
+
+
+def test_create_work_folders_creates_temp_and_output_dirs(tmp_path):
+    temp_dir = tmp_path / "tmp"
+    output_dir = tmp_path / "output"
+    manager = FileManager(temp_dir=str(temp_dir), output_dir=str(output_dir))
+
+    manager.create_work_folders()
+
+    assert temp_dir.is_dir()
+    assert output_dir.is_dir()
+
+
+def test_create_work_folders_is_idempotent(tmp_path):
+    temp_dir = tmp_path / "tmp"
+    manager = FileManager(temp_dir=str(temp_dir), output_dir=str(tmp_path / "output"))
+
+    manager.create_work_folders()
+    manager.create_work_folders()  # should not raise
+
+    assert temp_dir.is_dir()
+
+
+def test_clean_temp_folders_removes_files_and_directory(tmp_path):
+    temp_dir = tmp_path / "tmp"
+    temp_dir.mkdir()
+    (temp_dir / "a.wav").write_bytes(b"")
+    (temp_dir / "b.mp4").write_bytes(b"")
+    manager = FileManager(temp_dir=str(temp_dir), output_dir=str(tmp_path / "output"))
+
+    manager.clean_temp_folders()
+
+    assert not temp_dir.exists()
+
+
+def test_clean_temp_folders_on_empty_directory(tmp_path):
+    temp_dir = tmp_path / "tmp"
+    temp_dir.mkdir()
+    manager = FileManager(temp_dir=str(temp_dir), output_dir=str(tmp_path / "output"))
+
+    manager.clean_temp_folders()
+
+    assert not temp_dir.exists()
+
+
+def test_default_dirs_come_from_config():
+    from pkg import config as cfg
+
+    manager = FileManager()
+
+    assert manager.temp_dir == cfg.TEMP_DIR
+    assert manager.output_dir == cfg.OUTPUT_DIR
+    assert os.path.isabs(manager.temp_dir)

--- a/tests/unit/test_row.py
+++ b/tests/unit/test_row.py
@@ -1,0 +1,14 @@
+from models.row import Row
+
+
+def test_row_stores_text_and_lang():
+    row = Row(text="Hello world.", lang="en")
+
+    assert row.text == "Hello world."
+    assert row.lang == "en"
+
+
+def test_row_repr_includes_text_and_lang():
+    row = Row(text="Hello world.", lang="en")
+
+    assert repr(row) == "Row(text='Hello world.', lang='en')"

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -61,6 +61,13 @@ class TestValidateInput:
         with pytest.raises(ValueError, match="incorrectly formatted"):
             Task.validate_input("{1: {'text': 'Hello.'}}")
 
+    def test_raises_clean_error_when_entry_value_is_not_a_dict(self):
+        """Entry values that aren't dicts (e.g. a bare int) must raise the same clean
+        ValueError as any other malformed entry, not a TypeError from `"text" not in value`
+        being applied to a non-dict."""
+        with pytest.raises(ValueError, match="incorrectly formatted"):
+            Task.validate_input("{1: 5}")
+
     def test_raises_when_text_or_language_not_strings(self):
         with pytest.raises(ValueError, match="are not strings"):
             Task.validate_input("{1: {'text': 123, 'language': 'en'}}")

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -1,0 +1,79 @@
+import json
+
+import pytest
+
+from models.row import Row
+from models.task import Task
+
+
+class TestBuildFromString:
+    def test_builds_task_with_rows_from_valid_json(self):
+        task_string = json.dumps({1: {"text": "Hello.", "language": "en"}, 2: {"text": "Hola.", "language": "es"}})
+
+        task = Task.build_from_string("my task", 0, task_string)
+
+        assert task.name == "my task"
+        assert task.index == 0
+        assert len(task.rows) == 2
+        assert task.rows[0].text == "Hello."
+        assert task.rows[0].lang == "en"
+        assert task.rows[1].text == "Hola."
+        assert task.rows[1].lang == "es"
+
+    def test_raises_on_invalid_json(self):
+        with pytest.raises(ValueError, match="Invalid JSON format"):
+            Task.build_from_string("task", 0, "{not valid json")
+
+    def test_raises_when_top_level_is_not_a_dict(self):
+        with pytest.raises(ValueError, match="must represent a dictionary"):
+            Task.build_from_string("task", 0, json.dumps(["not", "a", "dict"]))
+
+    def test_raises_when_entry_is_not_a_dict(self):
+        task_string = json.dumps({"1": "not a dict"})
+
+        with pytest.raises(ValueError, match="each entry must be a dictionary"):
+            Task.build_from_string("task", 0, task_string)
+
+    def test_raises_when_text_or_language_missing(self):
+        task_string = json.dumps({"1": {"text": "Hello."}})
+
+        with pytest.raises(ValueError, match="Missing 'text' or 'language'"):
+            Task.build_from_string("task", 0, task_string)
+
+
+class TestValidateInput:
+    def test_returns_parsed_dict_for_valid_input(self):
+        text = "{1: {'text': 'Hello.', 'language': 'en'}}"
+
+        result = Task.validate_input(text)
+
+        assert result == {1: {"text": "Hello.", "language": "en"}}
+
+    def test_raises_when_top_level_is_not_a_dict(self):
+        with pytest.raises(ValueError, match="must be a dictionary"):
+            Task.validate_input("['not', 'a', 'dict']")
+
+    def test_raises_when_key_is_not_an_integer(self):
+        with pytest.raises(ValueError, match="is not an integer"):
+            Task.validate_input("{'1': {'text': 'Hello.', 'language': 'en'}}")
+
+    def test_raises_when_entry_missing_text_or_language(self):
+        with pytest.raises(ValueError, match="incorrectly formatted"):
+            Task.validate_input("{1: {'text': 'Hello.'}}")
+
+    def test_raises_when_text_or_language_not_strings(self):
+        with pytest.raises(ValueError, match="are not strings"):
+            Task.validate_input("{1: {'text': 123, 'language': 'en'}}")
+
+    def test_raises_on_malformed_literal(self):
+        with pytest.raises(ValueError):
+            Task.validate_input("not a valid python literal {{{")
+
+
+def test_add_row_appends_to_task():
+    task = Task(name="task", index=0)
+
+    task.add_row(Row(text="Hello.", lang="en"))
+
+    assert len(task.rows) == 1
+    assert task.rows[0].text == "Hello."


### PR DESCRIPTION
Closes #41

## Summary
- Adds unit test coverage for the three modules this issue explicitly names — `models/task.py`, `fh/hfiles.py`, `fh/haudio.py` — none of which had any tests before this session's TTS-adapter-focused work. `models/row.py` covered too (trivial, directly related).
- **Two real bugs fixed while adding coverage**, per `coding-standards.md`'s own policy of fixing a module's flagged anti-patterns on contact:
  - `Task.validate_input` returned the caught exception instead of raising it — its only caller already wraps the call in `try/except Exception`, so today a validation failure gets passed to `add_task()` as if it were valid data, raising a *second*, unrelated `TypeError` and showing the user a confusing error instead of the real validation message. Now raises directly.
  - `AudioManager.combine_audio_fragments` used `print()` instead of `logging` (inconsistent with `audio_video_generator.py`'s existing setup); also removed two dead imports (`subprocess`, `tqdm`) ruff flagged while touching this file's import block.
- `fh/haudio.py`'s tests generate small **real** WAV files via `pydub` rather than mocking it, verifying the actual frame-boundary-padding math and concatenation duration.

## Scope adjustment
The issue's original scope also asked for API integration tests (task queue, OpenAI-mocked content generation) — deferred, since no API endpoints exist yet (Épica A/B haven't started). "Mock the TTS engine in tests" was already done extensively across this session's earlier adapter work.

## Test plan
- [x] `pytest tests/` — 81 passed.
- [x] `ruff check`/`ruff format --check`/`mypy` clean on all touched files.
- [x] Security review (`/security-review`) — no findings.