### PR TITLE
Add queue-processing endpoint with SSE progress (#16)

### DIFF
--- a/adapters/driving/api/app.py
+++ b/adapters/driving/api/app.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from fastapi import FastAPI
 
 from adapters.driving.api.routes import router
@@ -8,8 +10,8 @@ from domain.progress_tracker import ProgressTracker
 
 def create_app(
     use_case: ManageTaskQueueUseCase,
-    process_queue_use_case: ProcessQueueUseCase | None = None,
-    progress_tracker: ProgressTracker | None = None,
+    process_queue_use_case: Optional[ProcessQueueUseCase] = None,
+    progress_tracker: Optional[ProgressTracker] = None,
 ) -> FastAPI:
     app = FastAPI(title="PodLitPy Task Queue API")
     app.state.use_case = use_case

--- a/adapters/driving/api/app.py
+++ b/adapters/driving/api/app.py
@@ -2,10 +2,18 @@ from fastapi import FastAPI
 
 from adapters.driving.api.routes import router
 from application.use_cases.manage_task_queue_use_case import ManageTaskQueueUseCase
+from application.use_cases.process_queue_use_case import ProcessQueueUseCase
+from domain.progress_tracker import ProgressTracker
 
 
-def create_app(use_case: ManageTaskQueueUseCase) -> FastAPI:
+def create_app(
+    use_case: ManageTaskQueueUseCase,
+    process_queue_use_case: ProcessQueueUseCase | None = None,
+    progress_tracker: ProgressTracker | None = None,
+) -> FastAPI:
     app = FastAPI(title="PodLitPy Task Queue API")
     app.state.use_case = use_case
+    app.state.process_queue_use_case = process_queue_use_case
+    app.state.progress_tracker = progress_tracker
     app.include_router(router)
     return app

--- a/adapters/driving/api/routes.py
+++ b/adapters/driving/api/routes.py
@@ -1,14 +1,31 @@
-from fastapi import APIRouter, Depends, HTTPException, Request
+import asyncio
+import json
+from dataclasses import asdict
 
-from adapters.driving.api.schemas import QueueReplaceRequest, TaskCreateRequest, TaskResponse
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from adapters.driving.api.schemas import QueueProcessRequest, QueueReplaceRequest, TaskCreateRequest, TaskResponse
 from application.use_cases.manage_task_queue_use_case import ManageTaskQueueUseCase
-from domain.exceptions import TaskNotFoundError
+from application.use_cases.process_queue_use_case import ProcessQueueUseCase
+from domain.exceptions import QueueAlreadyProcessingError, TaskNotFoundError
+from domain.progress_tracker import ProgressTracker
+
+PROGRESS_POLL_INTERVAL_SECONDS = 0.2
 
 router = APIRouter()
 
 
 def get_use_case(request: Request) -> ManageTaskQueueUseCase:
     return request.app.state.use_case
+
+
+def get_process_queue_use_case(request: Request) -> ProcessQueueUseCase:
+    return request.app.state.process_queue_use_case
+
+
+def get_progress_tracker(request: Request) -> ProgressTracker:
+    return request.app.state.progress_tracker
 
 
 def _to_response(record) -> TaskResponse:
@@ -69,3 +86,31 @@ def replace_queue(body: QueueReplaceRequest, use_case: ManageTaskQueueUseCase = 
     except ValueError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
     return [_to_response(record) for record in records]
+
+
+@router.post("/queue/process", status_code=202)
+def process_queue(
+    body: QueueProcessRequest,
+    process_queue_use_case: ProcessQueueUseCase = Depends(get_process_queue_use_case),
+):
+    try:
+        process_queue_use_case.start(task_delay_ms=body.task_delay_ms, mix_queue=body.mix_queue)
+    except QueueAlreadyProcessingError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+    return {"status": "started"}
+
+
+@router.get("/queue/progress")
+async def queue_progress(progress_tracker: ProgressTracker = Depends(get_progress_tracker)):
+    async def event_stream():
+        last_state = None
+        while True:
+            state = progress_tracker.state
+            if state != last_state:
+                yield f"data: {json.dumps(asdict(state))}\n\n"
+                last_state = state
+            if state.status == "completed":
+                break
+            await asyncio.sleep(PROGRESS_POLL_INTERVAL_SECONDS)
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")

--- a/adapters/driving/api/schemas.py
+++ b/adapters/driving/api/schemas.py
@@ -17,3 +17,8 @@ class TaskResponse(BaseModel):
 
 class QueueReplaceRequest(BaseModel):
     raw_texts: list[str]
+
+
+class QueueProcessRequest(BaseModel):
+    task_delay_ms: int = 0
+    mix_queue: bool = False

--- a/api_server.py
+++ b/api_server.py
@@ -2,12 +2,23 @@ import uvicorn
 
 from adapters.driven.persistence.json_task_repository import JsonTaskRepository
 from adapters.driving.api.app import create_app
+from app import build_tts_engine
 from application.use_cases.manage_task_queue_use_case import ManageTaskQueueUseCase
+from application.use_cases.process_queue_use_case import ProcessQueueUseCase
+from audio_video_generator import AudioVideoGenerator
+from domain.progress_tracker import ProgressTracker
 from pkg import config as cfg
 
 repository = JsonTaskRepository(storage_path=cfg.QUEUE_STORAGE_PATH)
 use_case = ManageTaskQueueUseCase(repository=repository)
-app = create_app(use_case)
+
+media_generator = AudioVideoGenerator(tts_engine=build_tts_engine(cfg.TTS_ENGINE))
+progress_tracker = ProgressTracker()
+process_queue_use_case = ProcessQueueUseCase(
+    repository=repository, media_generator=media_generator, progress_tracker=progress_tracker
+)
+
+app = create_app(use_case, process_queue_use_case=process_queue_use_case, progress_tracker=progress_tracker)
 
 if __name__ == "__main__":
     uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/application/use_cases/process_queue_use_case.py
+++ b/application/use_cases/process_queue_use_case.py
@@ -1,6 +1,6 @@
 import threading
 import time
-from typing import Any, Protocol
+from typing import Any, Optional, Protocol
 
 from application.ports.task_repository_port import TaskRepositoryPort
 from domain.exceptions import QueueAlreadyProcessingError
@@ -27,7 +27,7 @@ class ProcessQueueUseCase:
         self._repository = repository
         self._media_generator = media_generator
         self._progress_tracker = progress_tracker
-        self._thread: threading.Thread | None = None
+        self._thread: Optional[threading.Thread] = None
 
     def is_running(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
@@ -40,7 +40,7 @@ class ProcessQueueUseCase:
         self._thread = threading.Thread(target=self._run, args=(task_delay_ms, mix_queue), daemon=True)
         self._thread.start()
 
-    def wait_until_done(self, timeout: float | None = None) -> None:
+    def wait_until_done(self, timeout: Optional[float] = None) -> None:
         if self._thread is not None:
             self._thread.join(timeout=timeout)
 

--- a/application/use_cases/process_queue_use_case.py
+++ b/application/use_cases/process_queue_use_case.py
@@ -1,0 +1,66 @@
+import threading
+import time
+from typing import Any, Protocol
+
+from application.ports.task_repository_port import TaskRepositoryPort
+from domain.exceptions import QueueAlreadyProcessingError
+from domain.progress_tracker import ProgressTracker
+
+
+class MediaGenerator(Protocol):
+    """Structural contract for the collaborator that turns one task's data into output
+    files - matches AudioVideoGenerator's public shape without requiring inheritance from it,
+    so tests can supply a lightweight fake."""
+
+    def generate_files(self, text_to_speak: dict, progress_callback: Any) -> tuple[str, str]: ...
+
+    def combine_queue(self, processed_tasks: list, file_name: str = "") -> None: ...
+
+
+class ProcessQueueUseCase:
+    """Processes every task currently in the repository on a background thread, mirroring
+    WindowTaskQueueManager.process_next_task's threading/delay/mix_queue behavior for the API."""
+
+    def __init__(
+        self, repository: TaskRepositoryPort, media_generator: MediaGenerator, progress_tracker: ProgressTracker
+    ):
+        self._repository = repository
+        self._media_generator = media_generator
+        self._progress_tracker = progress_tracker
+        self._thread: threading.Thread | None = None
+
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def start(self, task_delay_ms: int = 0, mix_queue: bool = False) -> None:
+        if self.is_running():
+            raise QueueAlreadyProcessingError("Queue processing is already running")
+
+        self._progress_tracker.start()
+        self._thread = threading.Thread(target=self._run, args=(task_delay_ms, mix_queue), daemon=True)
+        self._thread.start()
+
+    def wait_until_done(self, timeout: float | None = None) -> None:
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+
+    def _run(self, task_delay_ms: int, mix_queue: bool) -> None:
+        records = self._repository.list_all()
+        total_tasks = len(records)
+        processed_outputs = []
+
+        for index, record in enumerate(records):
+
+            def progress_callback(progress: float, status: str = "Processing", index: int = index) -> None:
+                self._progress_tracker.update_current_task(index, total_tasks, progress, status)
+
+            output_files = self._media_generator.generate_files(record.data, progress_callback)
+            processed_outputs.append(output_files)
+
+            if task_delay_ms and index < total_tasks - 1:
+                time.sleep(task_delay_ms / 1000)
+
+        if mix_queue and processed_outputs:
+            self._media_generator.combine_queue(processed_outputs)
+
+        self._progress_tracker.complete()

--- a/domain/exceptions.py
+++ b/domain/exceptions.py
@@ -16,3 +16,7 @@ class LanguageNotSupportedError(Exception):
 
 class TaskNotFoundError(Exception):
     """Raised when a requested task id doesn't exist in the queue."""
+
+
+class QueueAlreadyProcessingError(Exception):
+    """Raised when queue processing is started while a previous run is still in progress."""

--- a/domain/progress_tracker.py
+++ b/domain/progress_tracker.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ProgressState:
+    status: str  # "idle" | "running" | "completed"
+    queue_progress: float = 0.0  # 0-100, overall
+    current_task_index: int | None = None
+    current_task_progress: float = 0.0  # 0-100, current task only
+    current_task_status: str = ""
+
+
+class ProgressTracker:
+    """In-memory progress state for the (single) task queue this app processes - matches
+    Tkinter's task_progress/queue_progress. One instance per running server; a restart mid-
+    processing loses progress state, same as the current Tkinter app losing it on close.
+    """
+
+    def __init__(self):
+        self._state = ProgressState(status="idle")
+
+    @property
+    def state(self) -> ProgressState:
+        return self._state
+
+    def start(self) -> None:
+        self._state = ProgressState(status="running")
+
+    def update_current_task(self, task_index: int, total_tasks: int, task_progress: float, status: str) -> None:
+        queue_progress = round((task_index + task_progress / 100) / total_tasks * 100, 2)
+        self._state = ProgressState(
+            status="running",
+            queue_progress=queue_progress,
+            current_task_index=task_index,
+            current_task_progress=task_progress,
+            current_task_status=status,
+        )
+
+    def complete(self) -> None:
+        self._state = ProgressState(status="completed", queue_progress=100.0)

--- a/domain/progress_tracker.py
+++ b/domain/progress_tracker.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
 class ProgressState:
     status: str  # "idle" | "running" | "completed"
     queue_progress: float = 0.0  # 0-100, overall
-    current_task_index: int | None = None
+    current_task_index: Optional[int] = None
     current_task_progress: float = 0.0  # 0-100, current task only
     current_task_status: str = ""
 

--- a/specs/queue-processing-progress-endpoint.md
+++ b/specs/queue-processing-progress-endpoint.md
@@ -1,0 +1,77 @@
+# Endpoint to process the queue with real-time progress
+
+Source: https://github.com/fxneiram/podlit_py/issues/16
+Branch: feature/queue-processing-progress-endpoint
+
+## Problem / goal
+
+Second issue of Épica A, building directly on #15's REST API. Expose
+`AudioVideoGenerator.generate_files`/`combine_queue` (today only reachable from
+`WindowTaskQueueManager`'s `progress_callback`-driven Tkinter flow) as an API operation, with
+real-time progress the frontend can display without aggressive polling.
+
+## Design decisions (confirm before implementation)
+
+**Server-Sent Events (SSE), not WebSocket.** The data flow here is one-directional
+(server → client progress pushes); nothing in this issue's scope needs the client to send
+messages back over the same channel during generation. SSE is simpler to implement (a plain
+`StreamingResponse` with `media_type="text/event-stream"`, no extra dependency) and is the
+standard fit for "push updates, no client-to-server chatter" — matches the acceptance criterion
+("sin hacer polling agresivo") without WebSocket's added complexity.
+
+**Background execution: a dedicated thread, mirroring the existing Tkinter pattern.**
+`WindowTaskQueueManager.process_next_task` already runs each task in its own
+`threading.Thread`, polls completion, and applies `task_delay` between tasks via
+`root.after`. The API version keeps the same shape — a single background thread iterates the
+queue, calls `generate_files` per task, sleeps `task_delay_ms` between tasks — rather than
+using FastAPI's `BackgroundTasks` (which runs on the request's own worker and isn't a good fit
+for a queue that can run far longer than any reasonable request timeout) or introducing a task
+queue system (Celery etc. — real overkill for a single-user local tool).
+
+**"Shutdown on complete" is out of scope for this endpoint.** The existing Tkinter feature
+(`shutdown_after_completion`, `os.system("shutdown /s /f /t 1")`) shuts down the *desktop
+machine* when a queue finishes — that doesn't translate sensibly to a web API that might be
+long-running on a shared or remote machine. Not porting it; flagging here so it isn't silently
+forgotten if a future issue wants an equivalent ("stop the server"?) concept.
+
+**Progress data model** — one in-memory `ProgressTracker` (matches `task_progress`/
+`queue_progress` in the Tkinter code):
+```python
+status: Literal["idle", "running", "completed"]
+queue_progress: float          # 0-100, overall
+current_task_index: int | None
+current_task_progress: float   # 0-100, current task only
+current_task_status: str       # e.g. "Processing fragment 2/5"
+```
+Single in-memory instance (this app has exactly one queue and one user) — no per-job ids, no
+persistence; a server restart mid-processing loses progress state (acceptable for this issue's
+scope, matching how the current Tkinter version doesn't survive an app restart either).
+
+## Endpoints
+
+- `POST /queue/process` — body: `{"task_delay_ms": 0, "mix_queue": false}`. Starts the
+  background thread (returns `409` if already running), processes every task currently in the
+  repository via `AudioVideoGenerator.generate_files`, applying `task_delay_ms` between tasks;
+  if `mix_queue` is true, calls `combine_queue` on the generated outputs once the loop
+  finishes. Returns `202` immediately.
+- `GET /queue/progress` — SSE stream of `ProgressTracker` state, one event whenever it
+  changes (polled internally at a short interval, not exposed as client-side polling).
+
+## Acceptance criteria
+
+1. `application/use_cases/process_queue_use_case.py`: `ProcessQueueUseCase` — background
+   thread, per-task + queue progress via `ProgressTracker`, `task_delay_ms`, `mix_queue`.
+2. `domain/progress_tracker.py` (or similar): the state model above.
+3. `adapters/driving/api/routes.py` (or a new `queue_routes.py`): `POST /queue/process`,
+   `GET /queue/progress` (SSE).
+4. `api_server.py` wires `AudioVideoGenerator` (via `app.py`'s existing `build_tts_engine`) and
+   `ProcessQueueUseCase` into the app alongside #15's existing pieces.
+5. Tests: `ProcessQueueUseCase` unit tests with a fake `TextToSpeechPort`/`AudioVideoGenerator`
+   double (per this project's established "don't touch real TTS/audio in tests" pattern) and a
+   fake repository; integration test driving `POST /queue/process` then reading the SSE stream
+   via `TestClient`, asserting progress reaches `"completed"`.
+6. `WindowTaskQueueManager`/`app.py`'s Tkinter flow unchanged.
+
+## Out of scope
+
+Shutdown-on-complete (see above). #17 (voices API), #18/#19 (frontend, Tkinter retirement).

--- a/tests/integration/test_queue_process_api.py
+++ b/tests/integration/test_queue_process_api.py
@@ -1,0 +1,123 @@
+"""Real FastAPI TestClient driving POST /queue/process and reading the GET /queue/progress SSE
+stream - only the media generator is faked (per this project's "don't touch real TTS/audio in
+tests" pattern); the repository, use case, and HTTP layer are all real.
+"""
+
+import json
+import threading
+
+import pytest
+from fastapi.testclient import TestClient
+
+from adapters.driven.persistence.json_task_repository import JsonTaskRepository
+from adapters.driving.api.app import create_app
+from application.use_cases.manage_task_queue_use_case import ManageTaskQueueUseCase
+from application.use_cases.process_queue_use_case import ProcessQueueUseCase
+from domain.progress_tracker import ProgressTracker
+
+VALID_TASK_TEXT = '{1: {"text": "Hello.", "language": "en"}}'
+
+
+class FakeMediaGenerator:
+    def __init__(self):
+        self.generate_files_calls = []
+        self.combine_queue_calls = []
+
+    def generate_files(self, text_to_speak, progress_callback):
+        progress_callback(100, "Done")
+        self.generate_files_calls.append(text_to_speak)
+        return "/output/1.wav", "/output/1.mp4"
+
+    def combine_queue(self, tasks, file_name=""):
+        self.combine_queue_calls.append((tasks, file_name))
+
+
+@pytest.fixture
+def wiring(tmp_path):
+    repository = JsonTaskRepository(storage_path=str(tmp_path / "queue.json"))
+    use_case = ManageTaskQueueUseCase(repository=repository)
+    media_generator = FakeMediaGenerator()
+    progress_tracker = ProgressTracker()
+    process_queue_use_case = ProcessQueueUseCase(
+        repository=repository, media_generator=media_generator, progress_tracker=progress_tracker
+    )
+    app = create_app(use_case, process_queue_use_case=process_queue_use_case, progress_tracker=progress_tracker)
+    return TestClient(app), use_case, media_generator, process_queue_use_case
+
+
+def _read_sse_events(response):
+    events = []
+    for line in response.iter_lines():
+        if line and line.startswith("data: "):
+            events.append(json.loads(line[len("data: ") :]))
+    return events
+
+
+def test_process_queue_returns_202_and_processes_every_task(wiring):
+    client, use_case, media_generator, process_queue_use_case = wiring
+    use_case.add_task(VALID_TASK_TEXT)
+    use_case.add_task(VALID_TASK_TEXT)
+
+    response = client.post("/queue/process", json={})
+
+    assert response.status_code == 202
+    process_queue_use_case.wait_until_done(timeout=5)
+    assert len(media_generator.generate_files_calls) == 2
+
+
+def test_process_queue_returns_409_when_already_running(tmp_path):
+    repository = JsonTaskRepository(storage_path=str(tmp_path / "queue.json"))
+    use_case = ManageTaskQueueUseCase(repository=repository)
+    use_case.add_task(VALID_TASK_TEXT)
+
+    release = threading.Event()
+    entered = threading.Event()
+
+    class BlockingMediaGenerator:
+        def generate_files(self, text_to_speak, progress_callback):
+            entered.set()
+            release.wait(timeout=5)
+            return "/output/1.wav", "/output/1.mp4"
+
+        def combine_queue(self, tasks, file_name=""):
+            pass
+
+    progress_tracker = ProgressTracker()
+    process_queue_use_case = ProcessQueueUseCase(
+        repository=repository, media_generator=BlockingMediaGenerator(), progress_tracker=progress_tracker
+    )
+    app = create_app(use_case, process_queue_use_case=process_queue_use_case, progress_tracker=progress_tracker)
+    client = TestClient(app)
+
+    client.post("/queue/process", json={})
+    entered.wait(timeout=5)
+
+    response = client.post("/queue/process", json={})
+
+    assert response.status_code == 409
+    release.set()
+    process_queue_use_case.wait_until_done(timeout=5)
+
+
+def test_process_queue_with_mix_queue_combines_outputs(wiring):
+    client, use_case, media_generator, process_queue_use_case = wiring
+    use_case.add_task(VALID_TASK_TEXT)
+
+    client.post("/queue/process", json={"mix_queue": True})
+    process_queue_use_case.wait_until_done(timeout=5)
+
+    assert len(media_generator.combine_queue_calls) == 1
+
+
+def test_progress_stream_reaches_completed(wiring):
+    client, use_case, _media_generator, process_queue_use_case = wiring
+    use_case.add_task(VALID_TASK_TEXT)
+    client.post("/queue/process", json={})
+    process_queue_use_case.wait_until_done(timeout=5)
+
+    with client.stream("GET", "/queue/progress") as response:
+        events = _read_sse_events(response)
+
+    assert events
+    assert events[-1]["status"] == "completed"
+    assert events[-1]["queue_progress"] == 100.0

--- a/tests/unit/test_process_queue_use_case.py
+++ b/tests/unit/test_process_queue_use_case.py
@@ -1,0 +1,154 @@
+import threading
+
+import pytest
+
+from application.ports.task_repository_port import TaskRepositoryPort
+from application.use_cases.process_queue_use_case import ProcessQueueUseCase
+from domain.exceptions import QueueAlreadyProcessingError
+from domain.progress_tracker import ProgressTracker
+from domain.task_record import TaskRecord
+
+
+class FakeTaskRepository(TaskRepositoryPort):
+    def __init__(self, records):
+        self._records = records
+
+    def add(self, data):
+        raise NotImplementedError
+
+    def list_all(self):
+        return self._records
+
+    def get(self, task_id):
+        raise NotImplementedError
+
+    def update(self, task_id, data):
+        raise NotImplementedError
+
+    def delete(self, task_id):
+        raise NotImplementedError
+
+    def replace_all(self, tasks_data):
+        raise NotImplementedError
+
+
+class FakeMediaGenerator:
+    def __init__(self):
+        self.generate_files_calls = []
+        self.combine_queue_calls = []
+
+    def generate_files(self, text_to_speak, progress_callback):
+        progress_callback(50, "Processing fragment 1/2")
+        progress_callback(100, "Done")
+        self.generate_files_calls.append(text_to_speak)
+        index = len(self.generate_files_calls)
+        return f"/output/{index}.wav", f"/output/{index}.mp4"
+
+    def combine_queue(self, tasks, file_name=""):
+        self.combine_queue_calls.append((tasks, file_name))
+
+
+@pytest.fixture
+def two_task_repository():
+    return FakeTaskRepository(
+        [
+            TaskRecord(id="a", data={1: {"text": "Hello.", "language": "en"}}),
+            TaskRecord(id="b", data={1: {"text": "Hola.", "language": "es"}}),
+        ]
+    )
+
+
+def test_start_processes_every_task_in_the_repository(two_task_repository):
+    media_generator = FakeMediaGenerator()
+    use_case = ProcessQueueUseCase(two_task_repository, media_generator, ProgressTracker())
+
+    use_case.start()
+    use_case.wait_until_done(timeout=5)
+
+    assert len(media_generator.generate_files_calls) == 2
+
+
+def test_start_updates_progress_tracker_to_completed(two_task_repository):
+    use_case = ProcessQueueUseCase(two_task_repository, FakeMediaGenerator(), (tracker := ProgressTracker()))
+
+    use_case.start()
+    use_case.wait_until_done(timeout=5)
+
+    assert tracker.state.status == "completed"
+    assert tracker.state.queue_progress == 100.0
+
+
+class BlockingMediaGenerator:
+    """generate_files blocks until release() is called, so the background thread is
+    guaranteed to still be alive when the test checks is_running()/start()."""
+
+    def __init__(self):
+        self._release = threading.Event()
+        self.entered = threading.Event()
+
+    def release(self):
+        self._release.set()
+
+    def generate_files(self, text_to_speak, progress_callback):
+        self.entered.set()
+        self._release.wait(timeout=5)
+        return "/output/1.wav", "/output/1.mp4"
+
+    def combine_queue(self, tasks, file_name=""):
+        pass
+
+
+def test_start_raises_if_already_running(two_task_repository):
+    media_generator = BlockingMediaGenerator()
+    use_case = ProcessQueueUseCase(two_task_repository, media_generator, ProgressTracker())
+    use_case.start()
+    media_generator.entered.wait(timeout=5)
+
+    with pytest.raises(QueueAlreadyProcessingError):
+        use_case.start()
+
+    media_generator.release()
+    use_case.wait_until_done(timeout=5)
+
+
+def test_mix_queue_true_combines_generated_outputs(two_task_repository):
+    media_generator = FakeMediaGenerator()
+    use_case = ProcessQueueUseCase(two_task_repository, media_generator, ProgressTracker())
+
+    use_case.start(mix_queue=True)
+    use_case.wait_until_done(timeout=5)
+
+    assert len(media_generator.combine_queue_calls) == 1
+
+
+def test_mix_queue_false_does_not_combine(two_task_repository):
+    media_generator = FakeMediaGenerator()
+    use_case = ProcessQueueUseCase(two_task_repository, media_generator, ProgressTracker())
+
+    use_case.start(mix_queue=False)
+    use_case.wait_until_done(timeout=5)
+
+    assert media_generator.combine_queue_calls == []
+
+
+def test_empty_queue_completes_immediately_without_calling_generate_files():
+    empty_repository = FakeTaskRepository([])
+    media_generator = FakeMediaGenerator()
+    use_case = ProcessQueueUseCase(empty_repository, media_generator, (tracker := ProgressTracker()))
+
+    use_case.start()
+    use_case.wait_until_done(timeout=5)
+
+    assert media_generator.generate_files_calls == []
+    assert tracker.state.status == "completed"
+
+
+def test_is_running_reflects_thread_state(two_task_repository):
+    use_case = ProcessQueueUseCase(two_task_repository, FakeMediaGenerator(), ProgressTracker())
+
+    assert use_case.is_running() is False
+
+    use_case.start()
+    use_case.wait_until_done(timeout=5)
+
+    assert use_case.is_running() is False

--- a/tests/unit/test_progress_tracker.py
+++ b/tests/unit/test_progress_tracker.py
@@ -1,0 +1,53 @@
+from domain.progress_tracker import ProgressTracker
+
+
+def test_initial_state_is_idle():
+    tracker = ProgressTracker()
+
+    assert tracker.state.status == "idle"
+    assert tracker.state.queue_progress == 0.0
+
+
+def test_start_sets_running_with_zero_progress():
+    tracker = ProgressTracker()
+
+    tracker.start()
+
+    assert tracker.state.status == "running"
+    assert tracker.state.queue_progress == 0.0
+
+
+def test_update_current_task_computes_overall_queue_progress():
+    """Mirrors WindowTaskQueueManager.update_queue_progress's formula:
+    (completed_tasks + current_task_fraction) / total_tasks * 100."""
+    tracker = ProgressTracker()
+    tracker.start()
+
+    # First of 4 tasks, halfway done
+    tracker.update_current_task(task_index=0, total_tasks=4, task_progress=50, status="Processing fragment 1/2")
+
+    assert tracker.state.status == "running"
+    assert tracker.state.current_task_index == 0
+    assert tracker.state.current_task_progress == 50
+    assert tracker.state.current_task_status == "Processing fragment 1/2"
+    assert tracker.state.queue_progress == 12.5  # (0 + 0.5) / 4 * 100
+
+
+def test_update_current_task_for_a_later_task_reflects_prior_completions():
+    tracker = ProgressTracker()
+    tracker.start()
+
+    # Third of 4 tasks (index 2), fully done
+    tracker.update_current_task(task_index=2, total_tasks=4, task_progress=100, status="Done")
+
+    assert tracker.state.queue_progress == 75.0  # (2 + 1.0) / 4 * 100
+
+
+def test_complete_sets_completed_status_and_full_progress():
+    tracker = ProgressTracker()
+    tracker.start()
+
+    tracker.complete()
+
+    assert tracker.state.status == "completed"
+    assert tracker.state.queue_progress == 100.0


### PR DESCRIPTION
## Summary
- Closes #16. Second issue of Épica A, built on #15's REST API.
- `POST /queue/process` starts processing the current queue on a background thread (mirrors `WindowTaskQueueManager.process_next_task`'s threading pattern), returns `202` immediately, `409` if already running.
- `GET /queue/progress` streams progress as Server-Sent Events (no WebSocket dependency, no client-side polling).
- New `ProgressTracker` (domain) and `ProcessQueueUseCase` (application) follow the same hexagonal-architecture/TDD pattern as #15.
- `api_server.py` wires a real `AudioVideoGenerator` (via `app.py`'s existing `build_tts_engine`) into the new use case; the Tkinter flow in `app.py`/`WindowTaskQueueManager` is untouched.
- "Shutdown on complete" intentionally out of scope (doesn't translate to a web API), as agreed before implementation.

## Test plan
- [x] `pytest` — 135 passed (full suite, including 7 new unit tests for `ProcessQueueUseCase`, 5 for `ProgressTracker`, 4 new integration tests for `POST /queue/process` + SSE stream via `TestClient`)
- [x] `ruff check` / `ruff format --check` clean on all new/changed files
- [x] Manual security self-review (`ReportFindings`) — no findings
- [x] mypy: pre-existing sandbox/anyio syntax error unrelated to this change (reproduces identically on `develop`, confirmed via `git stash`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)