### PR TITLE
Add voice management API: list, upload, select, speed (#17)

### DIFF
--- a/adapters/driven/tts/coqui_tts_adapter.py
+++ b/adapters/driven/tts/coqui_tts_adapter.py
@@ -52,5 +52,19 @@ class CoquiTTSAdapter(TextToSpeechPort):
     def supports_ssml(self) -> bool:
         return False
 
+    def supports_voice_upload(self) -> bool:
+        return True
+
+    def add_voice(self, filename: str, content: bytes) -> None:
+        # os.path.basename strips any directory components (e.g. "../../etc/passwd.wav"), so
+        # an uploaded filename can never write outside voices_dir.
+        safe_filename = os.path.basename(filename)
+        if not safe_filename.endswith(".wav"):
+            raise ValueError(f"Voice sample {filename!r} must be a .wav file")
+
+        with open(os.path.join(self.voices_dir, safe_filename), "wb") as voice_file:
+            voice_file.write(content)
+        self._voices = self._fetch_voices()
+
     def _fetch_voices(self) -> list[str]:
         return [name for name in os.listdir(self.voices_dir) if name.endswith(".wav")]

--- a/adapters/driven/tts/espeak_ng_adapter.py
+++ b/adapters/driven/tts/espeak_ng_adapter.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from application.ports.tts_port import TextToSpeechPort
-from domain.exceptions import TTSEngineUnavailableError, VoiceNotFoundError
+from domain.exceptions import TTSEngineUnavailableError, VoiceNotFoundError, VoiceUploadNotSupportedError
 
 DEFAULT_WORDS_PER_MINUTE = 175
 ESPEAK_NG_BINARY = "espeak-ng"
@@ -55,6 +55,12 @@ class EspeakNGAdapter(TextToSpeechPort):
 
     def supports_ssml(self) -> bool:
         return True
+
+    def supports_voice_upload(self) -> bool:
+        return False
+
+    def add_voice(self, filename: str, content: bytes) -> None:
+        raise VoiceUploadNotSupportedError("EspeakNGAdapter uses fixed system voices, no sample upload")
 
     def _fetch_voices(self) -> list[str]:
         try:

--- a/adapters/driven/tts/magpie_tts_adapter.py
+++ b/adapters/driven/tts/magpie_tts_adapter.py
@@ -2,7 +2,7 @@ import torch
 import torchaudio
 
 from application.ports.tts_port import TextToSpeechPort
-from domain.exceptions import SSMLNotSupportedError, VoiceNotFoundError
+from domain.exceptions import SSMLNotSupportedError, VoiceNotFoundError, VoiceUploadNotSupportedError
 
 MAGPIE_MODEL_NAME = "nvidia/magpie_tts_multilingual_357m"
 SAMPLE_RATE = 22050
@@ -61,6 +61,12 @@ class MagpieTTSAdapter(TextToSpeechPort):
 
     def supports_ssml(self) -> bool:
         return False
+
+    def supports_voice_upload(self) -> bool:
+        return False
+
+    def add_voice(self, filename: str, content: bytes) -> None:
+        raise VoiceUploadNotSupportedError("MagpieTTSAdapter uses a fixed set of baked-in speakers, no sample upload")
 
     @staticmethod
     def _voice_to_speaker_index(voice: str) -> int:

--- a/adapters/driven/tts/marytts_adapter.py
+++ b/adapters/driven/tts/marytts_adapter.py
@@ -8,6 +8,7 @@ from domain.exceptions import (
     SSMLNotSupportedError,
     TTSEngineUnavailableError,
     VoiceNotFoundError,
+    VoiceUploadNotSupportedError,
 )
 
 DEFAULT_BASE_URL = "http://localhost:59125"
@@ -105,6 +106,12 @@ class MaryTTSAdapter(TextToSpeechPort):
 
     def supports_ssml(self) -> bool:
         return False
+
+    def supports_voice_upload(self) -> bool:
+        return False
+
+    def add_voice(self, filename: str, content: bytes) -> None:
+        raise VoiceUploadNotSupportedError("MaryTTSAdapter uses server-side installed voices, no sample upload")
 
     def _fetch_voices(self) -> list[str]:
         try:

--- a/adapters/driving/api/app.py
+++ b/adapters/driving/api/app.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 
 from adapters.driving.api.routes import router
 from application.use_cases.manage_task_queue_use_case import ManageTaskQueueUseCase
+from application.use_cases.manage_voices_use_case import ManageVoicesUseCase
 from application.use_cases.process_queue_use_case import ProcessQueueUseCase
 from domain.progress_tracker import ProgressTracker
 
@@ -12,10 +13,12 @@ def create_app(
     use_case: ManageTaskQueueUseCase,
     process_queue_use_case: Optional[ProcessQueueUseCase] = None,
     progress_tracker: Optional[ProgressTracker] = None,
+    manage_voices_use_case: Optional[ManageVoicesUseCase] = None,
 ) -> FastAPI:
     app = FastAPI(title="PodLitPy Task Queue API")
     app.state.use_case = use_case
     app.state.process_queue_use_case = process_queue_use_case
     app.state.progress_tracker = progress_tracker
+    app.state.manage_voices_use_case = manage_voices_use_case
     app.include_router(router)
     return app

--- a/adapters/driving/api/routes.py
+++ b/adapters/driving/api/routes.py
@@ -2,13 +2,27 @@ import asyncio
 import json
 from dataclasses import asdict
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from fastapi.responses import StreamingResponse
 
-from adapters.driving.api.schemas import QueueProcessRequest, QueueReplaceRequest, TaskCreateRequest, TaskResponse
+from adapters.driving.api.schemas import (
+    QueueProcessRequest,
+    QueueReplaceRequest,
+    SelectVoiceRequest,
+    SetSpeedRequest,
+    TaskCreateRequest,
+    TaskResponse,
+    VoicesResponse,
+)
 from application.use_cases.manage_task_queue_use_case import ManageTaskQueueUseCase
+from application.use_cases.manage_voices_use_case import ManageVoicesUseCase
 from application.use_cases.process_queue_use_case import ProcessQueueUseCase
-from domain.exceptions import QueueAlreadyProcessingError, TaskNotFoundError
+from domain.exceptions import (
+    QueueAlreadyProcessingError,
+    TaskNotFoundError,
+    VoiceNotFoundError,
+    VoiceUploadNotSupportedError,
+)
 from domain.progress_tracker import ProgressTracker
 
 PROGRESS_POLL_INTERVAL_SECONDS = 0.2
@@ -26,6 +40,10 @@ def get_process_queue_use_case(request: Request) -> ProcessQueueUseCase:
 
 def get_progress_tracker(request: Request) -> ProgressTracker:
     return request.app.state.progress_tracker
+
+
+def get_manage_voices_use_case(request: Request) -> ManageVoicesUseCase:
+    return request.app.state.manage_voices_use_case
 
 
 def _to_response(record) -> TaskResponse:
@@ -114,3 +132,39 @@ async def queue_progress(progress_tracker: ProgressTracker = Depends(get_progres
             await asyncio.sleep(PROGRESS_POLL_INTERVAL_SECONDS)
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+
+@router.get("/voices", response_model=VoicesResponse)
+def list_voices(use_case: ManageVoicesUseCase = Depends(get_manage_voices_use_case)):
+    return VoicesResponse(voices=use_case.list_voices())
+
+
+@router.post("/voices", response_model=VoicesResponse, status_code=201)
+async def upload_voice(
+    file: UploadFile = File(...),
+    use_case: ManageVoicesUseCase = Depends(get_manage_voices_use_case),
+):
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="Uploaded file has no filename")
+
+    content = await file.read()
+    try:
+        use_case.upload_voice(file.filename, content)
+    except (VoiceUploadNotSupportedError, ValueError) as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return VoicesResponse(voices=use_case.list_voices())
+
+
+@router.post("/settings/voice")
+def select_voice(body: SelectVoiceRequest, use_case: ManageVoicesUseCase = Depends(get_manage_voices_use_case)):
+    try:
+        use_case.select_voice(body.voice)
+    except VoiceNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    return {"status": "ok"}
+
+
+@router.post("/settings/speed")
+def set_speed(body: SetSpeedRequest, use_case: ManageVoicesUseCase = Depends(get_manage_voices_use_case)):
+    use_case.set_speed(body.speed)
+    return {"status": "ok"}

--- a/adapters/driving/api/schemas.py
+++ b/adapters/driving/api/schemas.py
@@ -22,3 +22,15 @@ class QueueReplaceRequest(BaseModel):
 class QueueProcessRequest(BaseModel):
     task_delay_ms: int = 0
     mix_queue: bool = False
+
+
+class VoicesResponse(BaseModel):
+    voices: list[str]
+
+
+class SelectVoiceRequest(BaseModel):
+    voice: str
+
+
+class SetSpeedRequest(BaseModel):
+    speed: float

--- a/api_server.py
+++ b/api_server.py
@@ -4,6 +4,7 @@ from adapters.driven.persistence.json_task_repository import JsonTaskRepository
 from adapters.driving.api.app import create_app
 from app import build_tts_engine
 from application.use_cases.manage_task_queue_use_case import ManageTaskQueueUseCase
+from application.use_cases.manage_voices_use_case import ManageVoicesUseCase
 from application.use_cases.process_queue_use_case import ProcessQueueUseCase
 from audio_video_generator import AudioVideoGenerator
 from domain.progress_tracker import ProgressTracker
@@ -12,13 +13,20 @@ from pkg import config as cfg
 repository = JsonTaskRepository(storage_path=cfg.QUEUE_STORAGE_PATH)
 use_case = ManageTaskQueueUseCase(repository=repository)
 
-media_generator = AudioVideoGenerator(tts_engine=build_tts_engine(cfg.TTS_ENGINE))
+tts_engine = build_tts_engine(cfg.TTS_ENGINE)
+media_generator = AudioVideoGenerator(tts_engine=tts_engine)
 progress_tracker = ProgressTracker()
 process_queue_use_case = ProcessQueueUseCase(
     repository=repository, media_generator=media_generator, progress_tracker=progress_tracker
 )
+manage_voices_use_case = ManageVoicesUseCase(tts_engine=tts_engine, media_generator=media_generator)
 
-app = create_app(use_case, process_queue_use_case=process_queue_use_case, progress_tracker=progress_tracker)
+app = create_app(
+    use_case,
+    process_queue_use_case=process_queue_use_case,
+    progress_tracker=progress_tracker,
+    manage_voices_use_case=manage_voices_use_case,
+)
 
 if __name__ == "__main__":
     uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/application/ports/tts_port.py
+++ b/application/ports/tts_port.py
@@ -32,3 +32,15 @@ class TextToSpeechPort(ABC):
     @abstractmethod
     def supports_ssml(self) -> bool:
         """Whether this engine can accept `is_ssml=True` input."""
+
+    @abstractmethod
+    def supports_voice_upload(self) -> bool:
+        """Whether this engine can accept new voice samples via add_voice()."""
+
+    @abstractmethod
+    def add_voice(self, filename: str, content: bytes) -> None:
+        """Store a new voice sample so it appears in list_voices() afterwards.
+
+        Raises:
+            VoiceUploadNotSupportedError: if supports_voice_upload() is False.
+        """

--- a/application/use_cases/manage_voices_use_case.py
+++ b/application/use_cases/manage_voices_use_case.py
@@ -1,0 +1,41 @@
+from typing import Protocol
+
+from application.ports.tts_port import TextToSpeechPort
+from domain.exceptions import VoiceNotFoundError
+
+
+class VoiceSettingsManager(Protocol):
+    """Structural contract for the collaborator whose voice/speed settings this use case
+    manages - matches AudioVideoGenerator's public shape without requiring inheritance from it,
+    so tests can supply a lightweight fake."""
+
+    def load_voices(self) -> list[str]: ...
+
+    def change_voice(self, voice: str) -> None: ...
+
+    def set_speech_speed(self, speed: float) -> None: ...
+
+
+class ManageVoicesUseCase:
+    """Exposes voice listing/upload/selection and speech-speed control - what
+    AudioVideoGenerator.load_voices/change_voice/set_speech_speed already do, plus uploading a
+    new voice sample (a capability the Tkinter UI never had)."""
+
+    def __init__(self, tts_engine: TextToSpeechPort, media_generator: VoiceSettingsManager):
+        self._tts_engine = tts_engine
+        self._media_generator = media_generator
+
+    def list_voices(self) -> list[str]:
+        return self._media_generator.load_voices()
+
+    def upload_voice(self, filename: str, content: bytes) -> None:
+        self._tts_engine.add_voice(filename, content)
+        self._media_generator.load_voices()
+
+    def select_voice(self, voice: str) -> None:
+        if voice not in self._media_generator.load_voices():
+            raise VoiceNotFoundError(f"Voice {voice!r} not found")
+        self._media_generator.change_voice(voice)
+
+    def set_speed(self, speed: float) -> None:
+        self._media_generator.set_speech_speed(speed)

--- a/domain/exceptions.py
+++ b/domain/exceptions.py
@@ -20,3 +20,7 @@ class TaskNotFoundError(Exception):
 
 class QueueAlreadyProcessingError(Exception):
     """Raised when queue processing is started while a previous run is still in progress."""
+
+
+class VoiceUploadNotSupportedError(Exception):
+    """Raised when a new voice sample is uploaded to an engine whose adapter doesn't support it."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,6 @@ numpy==1.22.0
 fastapi==0.128.8
 uvicorn==0.39.0
 pydantic==2.13.4
+
+# Required at runtime by FastAPI's UploadFile/File(...) (POST /voices) - not a dev-only tool.
+python-multipart==0.0.20

--- a/specs/voices-api.md
+++ b/specs/voices-api.md
@@ -1,0 +1,85 @@
+# Voice management via API
+
+Source: https://github.com/fxneiram/podlit_py/issues/17
+Branch: feature/voices-api
+
+## Problem / goal
+
+Third issue of Épica A, building on #15/#16. Expose what `AudioVideoGenerator.load_voices` /
+`change_voice` / `set_speech_speed` already do (today only reachable from the Tkinter UI) as API
+operations, plus a new capability the Tkinter UI never had: uploading a new voice sample without
+touching the filesystem manually.
+
+## Design decisions
+
+**Voice upload is a `TextToSpeechPort` capability, not assumed for every engine.** The issue
+itself flags that a future TTS engine may not support voice-cloning-style sample uploads (only
+XTTS v2/Coqui does, among the four adapters that exist today). Mirrors the existing
+`supports_ssml()` / `SSMLNotSupportedError` pattern already on the port:
+- `TextToSpeechPort.supports_voice_upload() -> bool` (abstract, every adapter implements it)
+- `TextToSpeechPort.add_voice(filename: str, content: bytes) -> None` (abstract; raises
+  `VoiceUploadNotSupportedError` if `supports_voice_upload()` is `False`)
+- `CoquiTTSAdapter`: `supports_voice_upload` → `True`; `add_voice` writes `content` to
+  `voices_dir` under `os.path.basename(filename)` (path-traversal-safe — an uploaded filename
+  like `../../etc/passwd` must not escape `voices_dir`), requires a `.wav` extension (XTTS
+  speaker-reference format), and refreshes the cached voice list.
+- `EspeakNGAdapter`, `MaryTTSAdapter`, `MagpieTTSAdapter`: `supports_voice_upload` → `False`;
+  `add_voice` raises `VoiceUploadNotSupportedError`.
+
+**Voice selection / speed stay on the existing `AudioVideoGenerator` instance**, the same one
+`ProcessQueueUseCase` already holds (from #16) — `selected_voice`/`speech_speed` are read by
+`generate_files` per task, so there's exactly one source of truth, no new state to keep in sync.
+The new use case depends on a small structurally-typed `VoiceSettingsManager` (matches
+`AudioVideoGenerator.load_voices`/`change_voice`/`set_speech_speed`), the same `Protocol`-based
+pattern `ProcessQueueUseCase` used for its media generator dependency in #16 - keeps tests fast
+with a fake double instead of a real `AudioVideoGenerator`.
+
+**`POST /settings/voice` validates against the live voice list** (`VoiceNotFoundError` → 404) -
+an API boundary is exactly where CLAUDE.md's "validate at system boundaries" applies, unlike
+`AudioVideoGenerator.change_voice` today which sets `selected_voice` with no validation at all
+(that's existing Tkinter-flow behavior, left untouched). `POST /settings/speed` does **not**
+add new validation - `set_speech_speed` already clamps silently to `[0.1, 3.0]`, matching
+existing behavior.
+
+**New dependency**: `python-multipart==0.0.20`, required at runtime by FastAPI's
+`UploadFile`/`File(...)` — added to `requirements.txt` (not just `-dev`), verified installing
+cleanly in the real Python 3.9 venv alongside the existing pins (`pip check` clean, only the
+pre-existing unrelated `grpcio` platform warning).
+
+## Endpoints
+
+- `GET /voices` — `{"voices": [...]}`, the engine's current voice catalog.
+- `POST /voices` — multipart file upload (`file: UploadFile`). `201` with the updated voice
+  list on success; `400` if the active engine doesn't support voice upload
+  (`VoiceUploadNotSupportedError`) or the file isn't a `.wav`.
+- `POST /settings/voice` — body `{"voice": "..."}`. `200` on success; `404` if `voice` isn't in
+  the current voice list (`VoiceNotFoundError`).
+- `POST /settings/speed` — body `{"speed": 1.0}`. `200`, always succeeds (silently clamped).
+
+## Acceptance criteria
+
+1. `application/ports/tts_port.py`: add abstract `supports_voice_upload()` / `add_voice()`;
+   `domain/exceptions.py`: add `VoiceUploadNotSupportedError`.
+2. All four adapters (`coqui_tts_adapter.py`, `espeak_ng_adapter.py`, `marytts_adapter.py`,
+   `magpie_tts_adapter.py`) implement both new methods.
+3. `CoquiTTSAdapter.add_voice` is path-traversal-safe (basename only) and rejects non-`.wav`
+   filenames.
+4. `application/use_cases/manage_voices_use_case.py`: `ManageVoicesUseCase` with `list_voices`,
+   `upload_voice`, `select_voice`, `set_speed`.
+5. `adapters/driving/api/routes.py` (or a new `voice_routes.py`): the four endpoints above,
+   wired via a `get_manage_voices_use_case` dependency on `app.state`.
+6. `api_server.py` wires `ManageVoicesUseCase` (reusing the same `AudioVideoGenerator` instance
+   `ProcessQueueUseCase` already uses) into `create_app`.
+7. `requirements.txt` gets `python-multipart==0.0.20`.
+8. Tests: unit tests for `ManageVoicesUseCase` (fake `TextToSpeechPort` + fake
+   `VoiceSettingsManager`), unit tests for `CoquiTTSAdapter.add_voice` (real temp directory, real
+   file write, path-traversal + extension rejection cases) and for the other three adapters'
+   `supports_voice_upload`/`add_voice` behavior; integration test driving all four endpoints via
+   `TestClient` (including a real multipart upload).
+9. `WindowTaskQueueManager`/`app.py`'s Tkinter flow unchanged.
+
+## Out of scope
+
+Frontend (#18/#19). Deleting/renaming existing voices (issue only asks for list/upload/select).
+Per-adapter `voices_dir` configurability via `pkg/config.py` (not touched by this issue; already
+a constructor default today).

--- a/tests/integration/test_voices_api.py
+++ b/tests/integration/test_voices_api.py
@@ -1,0 +1,115 @@
+"""Real FastAPI TestClient (including a real multipart upload) against a fake TTS engine/media
+generator - only the actual TTS model and filesystem writes are faked, per this project's "don't
+touch real TTS/audio in tests" pattern.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from adapters.driven.persistence.json_task_repository import JsonTaskRepository
+from adapters.driving.api.app import create_app
+from application.use_cases.manage_task_queue_use_case import ManageTaskQueueUseCase
+from application.use_cases.manage_voices_use_case import ManageVoicesUseCase
+from domain.exceptions import VoiceUploadNotSupportedError
+
+
+class FakeTTSEngine:
+    def __init__(self, voices=None, upload_supported=True):
+        self._voices = voices or ["narrator.wav"]
+        self._upload_supported = upload_supported
+
+    def list_voices(self):
+        return self._voices
+
+    def supports_voice_upload(self):
+        return self._upload_supported
+
+    def add_voice(self, filename, content):
+        if not self._upload_supported:
+            raise VoiceUploadNotSupportedError("upload not supported")
+        self._voices.append(filename)
+
+
+class FakeMediaGenerator:
+    def __init__(self, tts_engine):
+        self._tts_engine = tts_engine
+        self.selected_voice = None
+        self.speech_speed = 1.0
+
+    def load_voices(self):
+        return self._tts_engine.list_voices()
+
+    def change_voice(self, voice):
+        self.selected_voice = voice
+
+    def set_speech_speed(self, speed):
+        self.speech_speed = max(0.1, min(3.0, speed))
+
+
+@pytest.fixture
+def wiring(tmp_path):
+    repository = JsonTaskRepository(storage_path=str(tmp_path / "queue.json"))
+    use_case = ManageTaskQueueUseCase(repository=repository)
+    tts_engine = FakeTTSEngine()
+    media_generator = FakeMediaGenerator(tts_engine)
+    manage_voices_use_case = ManageVoicesUseCase(tts_engine=tts_engine, media_generator=media_generator)
+    app = create_app(use_case, manage_voices_use_case=manage_voices_use_case)
+    return TestClient(app), tts_engine, media_generator
+
+
+def test_get_voices_returns_the_current_catalog(wiring):
+    client, _tts_engine, _media_generator = wiring
+
+    response = client.get("/voices")
+
+    assert response.status_code == 200
+    assert response.json() == {"voices": ["narrator.wav"]}
+
+
+def test_post_voices_uploads_a_new_sample(wiring):
+    client, _tts_engine, _media_generator = wiring
+
+    response = client.post("/voices", files={"file": ("second.wav", b"RIFF-fake-wav-bytes", "audio/wav")})
+
+    assert response.status_code == 201
+    assert response.json() == {"voices": ["narrator.wav", "second.wav"]}
+
+
+def test_post_voices_returns_400_when_engine_does_not_support_upload(tmp_path):
+    repository = JsonTaskRepository(storage_path=str(tmp_path / "queue.json"))
+    use_case = ManageTaskQueueUseCase(repository=repository)
+    tts_engine = FakeTTSEngine(upload_supported=False)
+    media_generator = FakeMediaGenerator(tts_engine)
+    manage_voices_use_case = ManageVoicesUseCase(tts_engine=tts_engine, media_generator=media_generator)
+    app = create_app(use_case, manage_voices_use_case=manage_voices_use_case)
+    client = TestClient(app)
+
+    response = client.post("/voices", files={"file": ("second.wav", b"content", "audio/wav")})
+
+    assert response.status_code == 400
+
+
+def test_select_voice_returns_200_and_updates_the_active_voice(wiring):
+    client, _tts_engine, media_generator = wiring
+
+    response = client.post("/settings/voice", json={"voice": "narrator.wav"})
+
+    assert response.status_code == 200
+    assert media_generator.selected_voice == "narrator.wav"
+
+
+def test_select_voice_returns_404_for_unknown_voice(wiring):
+    client, _tts_engine, _media_generator = wiring
+
+    response = client.post("/settings/voice", json={"voice": "missing.wav"})
+
+    assert response.status_code == 404
+
+
+def test_set_speed_returns_200_and_updates_the_speed(wiring):
+    client, _tts_engine, media_generator = wiring
+
+    response = client.post("/settings/speed", json={"speed": 1.5})
+
+    assert response.status_code == 200
+    assert media_generator.speech_speed == 1.5

--- a/tests/unit/test_audio_video_generator.py
+++ b/tests/unit/test_audio_video_generator.py
@@ -28,6 +28,12 @@ class FakeTTSAdapter(TextToSpeechPort):
     def supports_ssml(self):
         return False
 
+    def supports_voice_upload(self):
+        return False
+
+    def add_voice(self, filename, content):
+        raise NotImplementedError
+
 
 @pytest.fixture
 def mocked_media_managers():

--- a/tests/unit/test_coqui_tts_adapter.py
+++ b/tests/unit/test_coqui_tts_adapter.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -111,6 +112,40 @@ def test_list_voices_returns_wav_filenames_from_voices_dir(mock_tts_class, no_cu
     adapter = CoquiTTSAdapter(voices_dir=str(tmp_path))
 
     assert sorted(adapter.list_voices()) == ["narrator.wav", "second.wav"]
+
+
+def test_supports_voice_upload_is_true(mock_tts_class, no_cuda):
+    adapter = CoquiTTSAdapter()
+
+    assert adapter.supports_voice_upload() is True
+
+
+def test_add_voice_writes_file_and_refreshes_list(mock_tts_class, no_cuda, voices_dir):
+    adapter = CoquiTTSAdapter(voices_dir=voices_dir)
+
+    adapter.add_voice("second.wav", b"RIFF-fake-wav-bytes")
+
+    assert (Path(voices_dir) / "second.wav").read_bytes() == b"RIFF-fake-wav-bytes"
+    assert sorted(adapter.list_voices()) == ["narrator.wav", "second.wav"]
+
+
+def test_add_voice_rejects_non_wav_filename(mock_tts_class, no_cuda, voices_dir):
+    adapter = CoquiTTSAdapter(voices_dir=voices_dir)
+
+    with pytest.raises(ValueError):
+        adapter.add_voice("second.mp3", b"not a wav")
+
+    assert not (Path(voices_dir) / "second.mp3").exists()
+
+
+def test_add_voice_sanitizes_path_traversal_attempt(mock_tts_class, no_cuda, voices_dir):
+    adapter = CoquiTTSAdapter(voices_dir=voices_dir)
+    escaped_path = Path(voices_dir).parent / "etc" / "passwd.wav"
+
+    adapter.add_voice("../../etc/passwd.wav", b"payload")
+
+    assert (Path(voices_dir) / "passwd.wav").read_bytes() == b"payload"
+    assert not escaped_path.exists()
 
 
 def test_voices_are_fetched_once_at_construction_not_per_call(mock_tts_class, no_cuda, voices_dir):

--- a/tests/unit/test_espeak_ng_adapter.py
+++ b/tests/unit/test_espeak_ng_adapter.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from adapters.driven.tts.espeak_ng_adapter import EspeakNGAdapter
-from domain.exceptions import TTSEngineUnavailableError, VoiceNotFoundError
+from domain.exceptions import TTSEngineUnavailableError, VoiceNotFoundError, VoiceUploadNotSupportedError
 
 VOICES_OUTPUT = (
     "Pty Language       Age/Gender VoiceName          File                 Other Languages\n"
@@ -194,3 +194,18 @@ def test_supports_ssml_is_true(mock_run):
     adapter = EspeakNGAdapter()
 
     assert adapter.supports_ssml() is True
+
+
+def test_supports_voice_upload_is_false(mock_run):
+    mock_run.return_value = _voices_result()
+    adapter = EspeakNGAdapter()
+
+    assert adapter.supports_voice_upload() is False
+
+
+def test_add_voice_raises_voice_upload_not_supported(mock_run):
+    mock_run.return_value = _voices_result()
+    adapter = EspeakNGAdapter()
+
+    with pytest.raises(VoiceUploadNotSupportedError):
+        adapter.add_voice("narrator.wav", b"content")

--- a/tests/unit/test_magpie_tts_adapter.py
+++ b/tests/unit/test_magpie_tts_adapter.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from adapters.driven.tts.magpie_tts_adapter import MagpieTTSAdapter
-from domain.exceptions import SSMLNotSupportedError, VoiceNotFoundError
+from domain.exceptions import SSMLNotSupportedError, VoiceNotFoundError, VoiceUploadNotSupportedError
 
 
 class FakeMagpieTTSModel:
@@ -131,3 +131,16 @@ def test_supports_ssml_is_false(stubbed_nemo, mock_torchaudio_save):
     adapter = MagpieTTSAdapter()
 
     assert adapter.supports_ssml() is False
+
+
+def test_supports_voice_upload_is_false(stubbed_nemo, mock_torchaudio_save):
+    adapter = MagpieTTSAdapter()
+
+    assert adapter.supports_voice_upload() is False
+
+
+def test_add_voice_raises_voice_upload_not_supported(stubbed_nemo, mock_torchaudio_save):
+    adapter = MagpieTTSAdapter()
+
+    with pytest.raises(VoiceUploadNotSupportedError):
+        adapter.add_voice("speaker_0.wav", b"content")

--- a/tests/unit/test_manage_voices_use_case.py
+++ b/tests/unit/test_manage_voices_use_case.py
@@ -1,0 +1,98 @@
+import pytest
+
+from application.use_cases.manage_voices_use_case import ManageVoicesUseCase
+from domain.exceptions import VoiceNotFoundError, VoiceUploadNotSupportedError
+
+
+class FakeTTSEngine:
+    def __init__(self, voices=None, upload_supported=True):
+        self._voices = voices or ["narrator.wav"]
+        self._upload_supported = upload_supported
+        self.add_voice_calls = []
+
+    def list_voices(self):
+        return self._voices
+
+    def supports_voice_upload(self):
+        return self._upload_supported
+
+    def add_voice(self, filename, content):
+        if not self._upload_supported:
+            raise VoiceUploadNotSupportedError("upload not supported")
+        self.add_voice_calls.append((filename, content))
+        self._voices.append(filename)
+
+
+class FakeMediaGenerator:
+    def __init__(self, tts_engine):
+        self._tts_engine = tts_engine
+        self.selected_voice = None
+        self.speech_speed = 1.0
+
+    def load_voices(self):
+        return self._tts_engine.list_voices()
+
+    def change_voice(self, voice):
+        self.selected_voice = voice
+
+    def set_speech_speed(self, speed):
+        self.speech_speed = max(0.1, min(3.0, speed))
+
+
+@pytest.fixture
+def tts_engine():
+    return FakeTTSEngine()
+
+
+@pytest.fixture
+def media_generator(tts_engine):
+    return FakeMediaGenerator(tts_engine)
+
+
+@pytest.fixture
+def use_case(tts_engine, media_generator):
+    return ManageVoicesUseCase(tts_engine=tts_engine, media_generator=media_generator)
+
+
+def test_list_voices_returns_the_current_catalog(use_case):
+    assert use_case.list_voices() == ["narrator.wav"]
+
+
+def test_upload_voice_delegates_to_the_engine_and_refreshes_the_list(use_case, tts_engine):
+    use_case.upload_voice("second.wav", b"content")
+
+    assert tts_engine.add_voice_calls == [("second.wav", b"content")]
+    assert use_case.list_voices() == ["narrator.wav", "second.wav"]
+
+
+def test_upload_voice_raises_when_engine_does_not_support_it(tts_engine, media_generator):
+    tts_engine = FakeTTSEngine(upload_supported=False)
+    use_case = ManageVoicesUseCase(tts_engine=tts_engine, media_generator=FakeMediaGenerator(tts_engine))
+
+    with pytest.raises(VoiceUploadNotSupportedError):
+        use_case.upload_voice("second.wav", b"content")
+
+
+def test_select_voice_changes_the_active_voice(use_case, media_generator):
+    use_case.select_voice("narrator.wav")
+
+    assert media_generator.selected_voice == "narrator.wav"
+
+
+def test_select_voice_raises_when_voice_not_in_catalog(use_case):
+    with pytest.raises(VoiceNotFoundError):
+        use_case.select_voice("missing.wav")
+
+
+def test_set_speed_updates_the_media_generator(use_case, media_generator):
+    use_case.set_speed(1.5)
+
+    assert media_generator.speech_speed == 1.5
+
+
+def test_set_speed_relies_on_media_generator_clamping(use_case, media_generator):
+    """set_speech_speed already clamps to [0.1, 3.0] - the use case doesn't duplicate that
+    validation, it just forwards the value."""
+    use_case.set_speed(10.0)
+
+    assert media_generator.speech_speed == 3.0

--- a/tests/unit/test_marytts_adapter.py
+++ b/tests/unit/test_marytts_adapter.py
@@ -10,6 +10,7 @@ from domain.exceptions import (
     SSMLNotSupportedError,
     TTSEngineUnavailableError,
     VoiceNotFoundError,
+    VoiceUploadNotSupportedError,
 )
 
 VOICES_RESPONSE = b"alice-hsmm en_US female\nbits3-hsmm en_US male\n"
@@ -156,6 +157,21 @@ def test_supports_ssml_is_false(mock_urlopen):
     adapter = MaryTTSAdapter()
 
     assert adapter.supports_ssml() is False
+
+
+def test_supports_voice_upload_is_false(mock_urlopen):
+    mock_urlopen.return_value = _mock_response(VOICES_RESPONSE)
+    adapter = MaryTTSAdapter()
+
+    assert adapter.supports_voice_upload() is False
+
+
+def test_add_voice_raises_voice_upload_not_supported(mock_urlopen):
+    mock_urlopen.return_value = _mock_response(VOICES_RESPONSE)
+    adapter = MaryTTSAdapter()
+
+    with pytest.raises(VoiceUploadNotSupportedError):
+        adapter.add_voice("alice-hsmm.wav", b"content")
 
 
 def test_synthesize_raises_language_not_supported_for_spanish(mock_urlopen, tmp_path):


### PR DESCRIPTION
## Summary
- Closes #17. Third issue of Épica A, built on #15/#16.
- `TextToSpeechPort` gains `supports_voice_upload()` / `add_voice()`, mirroring the existing `supports_ssml()` pattern - only `CoquiTTSAdapter` (XTTS v2 voice-cloning samples) supports it; the other three adapters raise `VoiceUploadNotSupportedError`.
- `CoquiTTSAdapter.add_voice` sanitizes the uploaded filename (`os.path.basename`, so a path-traversal attempt can't write outside `voices_dir`) and requires a `.wav` extension.
- New `ManageVoicesUseCase` (list/upload/select voices, set speed) reuses the same `AudioVideoGenerator` instance `ProcessQueueUseCase` already holds - one source of truth for `selected_voice`/`speech_speed`.
- New endpoints: `GET /voices`, `POST /voices` (multipart upload), `POST /settings/voice` (404 if unknown), `POST /settings/speed` (silently clamped, matching existing behavior).
- New runtime dependency `python-multipart==0.0.20` (required by FastAPI's `UploadFile`), verified in the real Python 3.9 venv.

## Test plan
- [x] `pytest` — 156 passed (full suite) in the sandbox, and again in a real Python 3.9 venv (avoiding the `X | None` PEP 604 issue that broke CI on #54 - only `typing.Optional` used here)
- [x] `ruff check` / `ruff format --check` clean on all new/changed files
- [x] Manual security self-review (`ReportFindings`) — no findings; path-traversal on voice upload specifically covered by a unit test
- [x] Unit tests: all 4 TTS adapters' new capability methods, `ManageVoicesUseCase`
- [x] Integration tests: all 4 endpoints via `TestClient`, including a real multipart upload
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)